### PR TITLE
Validate inputs against schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,9 @@ The distances can also be used to produce a dendrogram, showing the result of hi
 ![Dendrogram](./docs/example-dendrogram.png)
 
 ## Dependencies
-- NumPy
+- jsonschema
 - Matplotlib
+- NumPy
 - Python 3
 - PyYAML
 - SciPy

--- a/codebasin/schema/compilation-database.schema
+++ b/codebasin/schema/compilation-database.schema
@@ -1,0 +1,42 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/intel/code-base-investigator/schema/compilation-database.schema",
+  "title": "Compilation Database",
+  "description": "Compilation database format used by many projects.",
+  "type": "array",
+  "items": {
+    "type": "object",
+    "properties": {
+      "directory": {
+        "type": "string"
+      },
+      "arguments": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      },
+      "file": {
+        "type": "string"
+      },
+      "command": {
+        "type": "string"
+      },
+      "output": {
+        "type": "string"
+      },
+    },
+    "anyOf": [
+      {
+        "required": [
+          "arguments",
+        ],
+      },
+      {
+        "required": [
+          "command",
+        ]
+      }
+    ]
+  }
+}

--- a/codebasin/schema/config.schema
+++ b/codebasin/schema/config.schema
@@ -1,0 +1,80 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/intel/code-base-investigator/schema/config.schema",
+  "title": "Code Base Investigator Configuration File",
+  "description": "Lists codebase files and compilation options",
+  "type": "object",
+  "properties": {
+    "codebase": {
+      "type": "object",
+      "properties": {
+        "files": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "platforms": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "exclude_files": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "files",
+        "platforms"
+      ]
+    }
+  },
+  "patternProperties": {
+    ".*": {
+      "type": "object",
+      "properties": {
+        "files": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "defines": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "include_paths": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "commands": {
+          "type": "string"
+        }
+      },
+      "anyOf": [
+        {
+          "required": [
+            "files"
+          ]
+        },
+        {
+          "required": [
+            "commands"
+          ]
+        }
+      ]
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "codebase"
+  ]
+}

--- a/examples/disjoint-source/disjoint-source.yaml
+++ b/examples/disjoint-source/disjoint-source.yaml
@@ -5,7 +5,7 @@
 
 codebase:
     files: [ "cpu/*.cpp", "gpu/*.cpp" ]
-    platforms: [ CPU, GPU ]
+    platforms: [ "CPU", "GPU" ]
 
 CPU:
     files: [ "cpu/*.cpp" ]

--- a/examples/divergent-source/divergent-source.yaml
+++ b/examples/divergent-source/divergent-source.yaml
@@ -5,11 +5,11 @@
 
 codebase:
     files: [ "*.cpp", "*.h" ]
-    platforms: [ CPU, GPU ]
+    platforms: [ "CPU", "GPU" ]
 
 CPU:
     files: [ "main.cpp", "private_histogram.cpp" ]
 
 GPU:
     files: [ "main.cpp", "shared_histogram.cpp" ]
-    defines: [ -DUSE_OFFLOAD ]
+    defines: [ "-DUSE_OFFLOAD" ]

--- a/examples/single-source/single-source.yaml
+++ b/examples/single-source/single-source.yaml
@@ -5,7 +5,7 @@
 
 codebase:
     files: [ "*.cpp" ]
-    platforms: [ CPU, GPU ]
+    platforms: [ "CPU", "GPU" ]
 
 CPU:
     files: [ "*.cpp" ]

--- a/setup.py
+++ b/setup.py
@@ -22,5 +22,6 @@ setup(name='codebasin',
       install_requires=['numpy',
                         'matplotlib',
                         'pyyaml',
-                        'scipy']
+                        'scipy',
+                        'jsonschema']
       )

--- a/tests/schema/__init__.py
+++ b/tests/schema/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2019-2023 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause

--- a/tests/schema/compile_commands.json
+++ b/tests/schema/compile_commands.json
@@ -1,0 +1,13 @@
+[
+    {
+        "arguments": [
+            "gcc",
+            "-c",
+            "-o",
+            "output",
+            "test.cpp"
+        ],
+        "directory": "/path/containing/source/files/",
+        "file": "test.cpp"
+    }
+]

--- a/tests/schema/config.yaml
+++ b/tests/schema/config.yaml
@@ -1,0 +1,7 @@
+codebase:
+    files: [ "*.cpp" ]
+    platforms: [ "CPU" ]
+
+CPU:
+    files: [ "*.cpp" ]
+    defines: [ "-D CPU" ]

--- a/tests/schema/invalid_compile_commands.json
+++ b/tests/schema/invalid_compile_commands.json
@@ -1,0 +1,13 @@
+[
+    {
+        "arguments": [
+            "gcc",
+            "-c",
+            "-o",
+            "output",
+            "test.cpp"
+        ],
+        "directory": ["not", "a", "directory"],
+        "file": "test.cpp"
+    }
+]

--- a/tests/schema/invalid_config.yaml
+++ b/tests/schema/invalid_config.yaml
@@ -1,0 +1,7 @@
+codebase:
+    files: [ "*.cpp" ]
+    platforms: [ "CPU" ]
+
+CPU:
+    files: [ "*.cpp" ]
+    defines: "-D CPU"

--- a/tests/schema/test.cpp
+++ b/tests/schema/test.cpp
@@ -1,0 +1,2 @@
+// Empty test.cpp required to prevent a RuntimeError during the test.
+// All files referenced by the config file must exist.

--- a/tests/schema/test_schema.py
+++ b/tests/schema/test_schema.py
@@ -24,5 +24,15 @@ class TestSchema(unittest.TestCase):
             path = "./tests/schema/invalid_compile_commands.json"
             db = config.load_database(path, "")
 
+    def test_configuration_file(self):
+        """schema/configuration_file"""
+
+        path = "./tests/schema/config.yaml"
+        config.load(path, "./tests/schema/")
+
+        with self.assertRaises(ValueError):
+            path = "./tests/schema/invalid_config.yaml"
+            config.load(path, "")
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/schema/test_schema.py
+++ b/tests/schema/test_schema.py
@@ -1,0 +1,28 @@
+# Copyright (C) 2019-2023 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+
+import unittest
+import logging
+
+import codebasin.config as config
+
+class TestSchema(unittest.TestCase):
+    """
+    Test schema validation of input files.
+    """
+
+    def setUp(self):
+        logging.getLogger("codebasin").disabled = True
+
+    def test_compilation_database(self):
+        """schema/compilation_database"""
+
+        path = "./tests/schema/compile_commands.json"
+        db = config.load_database(path, "")
+
+        with self.assertRaises(ValueError):
+            path = "./tests/schema/invalid_compile_commands.json"
+            db = config.load_database(path, "")
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Adds the ability to validate the following inputs against a schema:
- YAML configuration files.
- JSON compilation databases.