### PR TITLE
Export coverage for P3 Analysis Library

### DIFF
--- a/codebasin/util.py
+++ b/codebasin/util.py
@@ -15,6 +15,40 @@ import hashlib
 
 import logging
 
+import json
+import jsonschema
+
+_coverage_schema_id = (
+    "https://raw.githubusercontent.com/intel/"
+    "p3-analysis-library/p3/schema/coverage-0.1.0.schema"
+)
+_coverage_schema = {
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "$id": _coverage_schema_id,
+    "title": "Coverage",
+    "description": "Lines of code used in each file of a code base.",
+    "type": "array",
+    "items": {
+        "type": "object",
+        "properties": {
+            "file": {"type": "string"},
+            "regions": {
+                "type": "array",
+                "items": {
+                    "type": "array",
+                    "prefixItems": [
+                        {"type": "integer"},
+                        {"type": "integer"},
+                        {"type": "integer"},
+                    ],
+                    "items": False,
+                },
+            },
+        },
+        "required": ["file", "regions"],
+    },
+}
+
 log = logging.getLogger("codebasin")
 
 
@@ -87,3 +121,39 @@ def valid_path(path):
         valid = False
 
     return valid
+
+
+def validate_coverage_json(json_string: str) -> bool:
+    """
+    Validate coverage JSON string against schema.
+
+    Parameters
+    ----------
+    json_string : String
+        The JSON string to validate.
+
+    Returns
+    -------
+    bool
+        True if the JSON string is valid.
+
+    Raises
+    ------
+    ValueError
+        If the JSON string fails to validate.
+
+    TypeError
+        If the JSON string is not a string.
+    """
+    if not isinstance(json_string, str):
+        raise TypeError("Coverage must be a JSON string.")
+
+    instance = json.loads(json_string)
+
+    try:
+        jsonschema.validate(instance=instance, schema=_coverage_schema)
+    except Exception:
+        msg = "Coverage string failed schema validation"
+        raise ValueError(msg)
+
+    return True

--- a/codebasin/walkers/exporter.py
+++ b/codebasin/walkers/exporter.py
@@ -1,0 +1,53 @@
+# Copyright (C) 2019-2023 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+
+import logging
+import collections
+
+from .tree_walker import TreeWalker
+from codebasin.preprocessor import FileNode, CodeNode
+from codebasin import util
+
+log = logging.getLogger('codebasin')
+
+
+def exclude(filename, cb):
+    return (filename not in cb["files"] or filename in cb["exclude_files"])
+
+
+class Exporter(TreeWalker):
+    """
+    Build a per-platform list of mappings.
+    """
+
+    def __init__(self, codebase):
+        super().__init__(None, None)
+        self.codebase = codebase
+        self.exports = None
+
+    def walk(self, state):
+        self.exports = collections.defaultdict(lambda: collections.defaultdict(list))
+        for fn in state.get_filenames():
+            hashed_fn = util.compute_file_hash(fn)
+            self._export_node(hashed_fn, state.get_tree(fn).root, state.get_map(fn))
+        return self.exports
+
+    def _export_node(self, _filename, _node, _map):
+        # Do not export files that the user does not consider to be part of
+        # the codebase
+        if isinstance(_node, FileNode) and exclude(_node.filename, self.codebase):
+            return
+
+        if isinstance(_node, CodeNode):
+            association = _map[_node]
+            for p in frozenset(association):
+                start_line = _node.start_line
+                end_line = _node.end_line
+                num_lines = _node.num_lines
+                self.exports[p][_filename].append((start_line, end_line, num_lines))
+
+        next_filename = _filename
+        if isinstance(_node, FileNode):
+            next_filename = util.compute_file_hash(_node.filename)
+        for child in _node.children:
+            self._export_node(next_filename, child, _map)

--- a/etc/coverage.py
+++ b/etc/coverage.py
@@ -62,5 +62,7 @@ if __name__ == '__main__':
             for region in exports[p][filename]:
                 covobject["regions"].append(region)
             covarray.append(covobject)
+        json_string = json.dumps(covarray)
+        util.validate_coverage_json(json_string)
         with open(covpath, 'w') as fp:
-            fp.write(json.dumps(covarray))
+            fp.write(json_string)

--- a/etc/coverage.py
+++ b/etc/coverage.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+# Copyright (C) 2019-2023 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+"""
+Calculates the lines of code used by a single platform, as described by a
+compilation database, and outputs coverage in the P3 Analysis Library format.
+"""
+
+import argparse
+import json
+import os
+import sys
+import logging
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.realpath(__file__))))
+from codebasin.walkers.exporter import Exporter  # nopep8
+import codebasin.config as config  # nopep8
+import codebasin.finder as finder  # nopep8
+import codebasin.util as util  # nopep8
+
+if __name__ == '__main__':
+
+    # Read command-line arguments
+    desc = 'Code Base Investigator Coverage Tool'
+    parser = argparse.ArgumentParser(description=desc)
+    parser.add_argument('ifile', metavar='INPUT',
+                        help="path to compilation database JSON file")
+    parser.add_argument('ofile', metavar='OUTPUT',
+                        help="path to coverage JSON file")
+    args = parser.parse_args()
+
+    dbpath = os.path.realpath(args.ifile)
+    covpath = os.path.realpath(args.ofile)
+    for path in [dbpath, covpath]:
+        if not util.valid_path(path):
+            raise ValueError("%s is not a valid path." % path)
+        if not util.ensure_ext(path, ['.json']):
+            raise ValueError("%s is not a JSON file." % path)
+
+    # Ensure regular CBI output goes to stderr
+    stderr_log = logging.StreamHandler(sys.stderr)
+    stderr_log.setFormatter(logging.Formatter('[%(levelname)-8s] %(message)s'))
+    logging.getLogger('codebasin').addHandler(stderr_log)
+    logging.getLogger('codebasin').setLevel(logging.WARNING)
+
+    # Run CBI configured as-if:
+    # - configuration contains a single (dummy) platform
+    # - codebase contains all files in the specified compilation database
+    db = config.load_database(dbpath, os.getcwd())
+    configuration = {'cli': db}
+    files = [e['file'] for e in db]
+    codebase = {'files': files, 'platforms': ['cli'], 'exclude_files': []}
+
+    state = finder.find(os.getcwd(), codebase, configuration)
+
+    exporter = Exporter(codebase)
+    exports = exporter.walk(state)
+    for p in codebase['platforms']:
+        covarray = []
+        for filename in exports[p]:
+            covobject = {"file": filename, "regions": []}
+            for region in exports[p][filename]:
+                covobject["regions"].append(region)
+            covarray.append(covobject)
+        with open(covpath, 'w') as fp:
+            fp.write(json.dumps(covarray))


### PR DESCRIPTION
Exporting to this format enables several new features:
- Repeating divergence calculations without parsing source code
- Computing divergence for dynamic platform sets
- Interoperability with the [P3 Analysis Library](github.com/intel/p3-analysis-library)