### PR TITLE
Improve usability for large projects

### DIFF
--- a/codebasin/config.py
+++ b/codebasin/config.py
@@ -444,4 +444,8 @@ def load(config_file, rootdir):
     if not codebase["files"]:
         raise RuntimeError("No files remain after processing 'exclude_files'.")
 
+    # Store the rootdir in the codebase for use later in exclude()
+    if 'rootdir' not in codebase:
+        codebase['rootdir'] = os.path.realpath(rootdir)
+
     return codebase, configuration

--- a/codebasin/config.py
+++ b/codebasin/config.py
@@ -266,8 +266,8 @@ def load_codebase(config, rootdir):
         codebase["files"] = list(it.chain(*(expand_path(os.path.join(rootdir, f))
                                             for f in cfg_codebase["files"])))
         if not codebase["files"]:
-          raise RuntimeError("Codebase configuration contains no valid files. " +
-                             "Check regular expressions and working directory.")
+            raise RuntimeError("Codebase configuration contains no valid files. " +
+                               "Check regular expressions and working directory.")
 
         codebase["files"] = list(set(codebase["files"]).difference(codebase["exclude_files"]))
         if not codebase["files"]:

--- a/codebasin/config.py
+++ b/codebasin/config.py
@@ -248,7 +248,7 @@ def load_codebase(config, rootdir):
     if not cfg_codebase:
         raise RuntimeError("Empty 'codebase' section found in config file!")
     if "files" not in cfg_codebase:
-        raise RuntimeError("Empty 'files' section found in codebase definition!")
+        raise RuntimeError("No 'files' section found in codebase definition!")
     if "platforms" not in cfg_codebase or cfg_codebase["platforms"] == []:
         raise RuntimeError("Empty 'platforms' section found in codebase definition!")
 

--- a/codebasin/walkers/exporter.py
+++ b/codebasin/walkers/exporter.py
@@ -5,14 +5,11 @@ import logging
 import collections
 
 from .tree_walker import TreeWalker
+from .platform_mapper import exclude
 from codebasin.preprocessor import FileNode, CodeNode
 from codebasin import util
 
 log = logging.getLogger('codebasin')
-
-
-def exclude(filename, cb):
-    return (filename not in cb["files"] or filename in cb["exclude_files"])
 
 
 class Exporter(TreeWalker):

--- a/codebasin/walkers/platform_mapper.py
+++ b/codebasin/walkers/platform_mapper.py
@@ -19,7 +19,7 @@ def exclude(filename, cb):
     else:
       path = os.path.realpath(filename)
       if not path.startswith(cb['rootdir']):
-        log.warning(f"Excluding {filename}; outside of root directory.")
+        log.info(f"Excluding {filename}; outside of root directory.")
         return True
 
     return False

--- a/codebasin/walkers/platform_mapper.py
+++ b/codebasin/walkers/platform_mapper.py
@@ -3,13 +3,27 @@
 
 import logging
 import collections
+import os
 from .tree_mapper import TreeMapper
 from codebasin.preprocessor import FileNode, CodeNode
 
 log = logging.getLogger('codebasin')
 
 def exclude(filename, cb):
-    return (filename not in cb["files"] or filename in cb["exclude_files"])
+
+    if filename in cb['exclude_files']:
+      log.info(f"Excluding {filename}; matches 'exclude_files'.")
+      return True
+    elif filename in cb['files']:
+      return False
+    else:
+      path = os.path.realpath(filename)
+      if not path.startswith(cb['rootdir']):
+        log.warning(f"Excluding {filename}; outside of root directory.")
+        return True
+
+    return False
+
 
 class PlatformMapper(TreeMapper):
     """

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,11 +41,11 @@ The configuration file is structured as a mapping at the top level. A single `co
 A `codebase` key is required, which should contain a mapping containing: the key `files`, which is a sequence of file specifiers, and `platforms`, which is a sequence of user-defined names for platforms to be considered.
 
     codebase:
-        files: [ <file-spec>,+ ]
+        files: [ <file-spec>,* ]
         platforms: [ <platform-name>,+ ]
         exclude_files: [ <exclude-spec>,* ]
 
-The `<file-spec>` is a string that specifies a (relative) path to files in the source tree. It can be a literal path to a file, or globs are supported (for Python 3.5 and later).  The files are expanded with respect to the `--rootdir` specified on the commandline at invocation, or the default, which is the working directory where Code Base Investigator was invoked.
+The `<file-spec>` is a string that specifies a (relative) path to files in the source tree. It can be a literal path to a file, or globs are supported (for Python 3.5 and later).  The files are expanded with respect to the `--rootdir` specified on the commandline at invocation, or the default, which is the working directory where Code Base Investigator was invoked. If `files` is an empty list, CBI will determine the contents of the codebase automatically based on the files in the platform definition(s).
 
 `<platform-name>` can be any string; they are referred to by later platform definitions in the configuration file.
 


### PR DESCRIPTION
The changes here significantly improve usability for large codes, by:

1. **Removing the need to exhaustively list all files in the codebase or construct matching regular expressions.**
This is unrealistic for complex codebases, and unnecessary for analyses driven by compilation databases.

2. **Removing the need to exhaustively list all files that are *not* in the codebase.**
This is unrealistic for any codebase, as most developers do not know the path to standard headers (and the path may be different for different compilers and toolchains).

With these changes, Code Base Investigator can now support analysis of large and complex applications.