### PR TITLE
Add warning for missing include files

### DIFF
--- a/codebasin/preprocessor.py
+++ b/codebasin/preprocessor.py
@@ -843,6 +843,10 @@ class IncludeNode(DirectiveNode):
             associator = TreeAssociator(kwargs['state'].get_tree(
                 include_file), kwargs['state'].get_map(include_file))
             associator.walk(kwargs['platform'], kwargs['state'])
+        else:
+            filename = kwargs['filename']
+            line = self.start_line
+            log.warning(f"{filename}:{line}: '{include_path}' not found")
 
 
 class IfNode(DirectiveNode):

--- a/codebasin/preprocessor.py
+++ b/codebasin/preprocessor.py
@@ -843,7 +843,8 @@ class IncludeNode(DirectiveNode):
             associator = TreeAssociator(kwargs['state'].get_tree(
                 include_file), kwargs['state'].get_map(include_file))
             associator.walk(kwargs['platform'], kwargs['state'])
-        else:
+
+        if not include_file:
             filename = kwargs['filename']
             line = self.start_line
             log.warning(f"{filename}:{line}: '{include_path}' not found")


### PR DESCRIPTION
Omitting an include may be a deliberate attempt to accelerate analysis, but it's often a mistake. Missing includes may impact the evaluation of macros and shouldn't be silently ignored.