### PR TITLE
Improve warning message for unrecognized directive

### DIFF
--- a/codebasin/preprocessor.py
+++ b/codebasin/preprocessor.py
@@ -1352,8 +1352,13 @@ class DirectiveParser(Parser):
             # warnings for common directives that shouldn't impact
             # correctness.
             common_unhandled = ["line", "warning", "error"]
-            if len(self.tokens) > 2 and str(self.tokens[1]) not in common_unhandled:
-                log.warning("Unrecognized directive")
+            if len(self.tokens) >= 2 and str(self.tokens[1]) not in common_unhandled:
+                filename = "<unknown>"
+                line = self.tokens[0].line
+                column = self.tokens[0].col
+                spelling = toklist_print(self.tokens)
+                message = f"unrecognized directive '{spelling}'"
+                log.warning(f"{filename}:{line}:{column}: {message}")
             return UnrecognizedDirectiveNode(self.tokens)
         except ParseError:
             raise ParseError("Not a directive.")

--- a/codebasin/preprocessor.py
+++ b/codebasin/preprocessor.py
@@ -1347,18 +1347,6 @@ class DirectiveParser(Parser):
                 except ParseError:
                     pass
 
-            # Any other line beginning with '#' is a preprocessor
-            # directive, we just don't handle it (yet). Suppress
-            # warnings for common directives that shouldn't impact
-            # correctness.
-            common_unhandled = ["line", "warning", "error"]
-            if len(self.tokens) >= 2 and str(self.tokens[1]) not in common_unhandled:
-                filename = "<unknown>"
-                line = self.tokens[0].line
-                column = self.tokens[0].col
-                spelling = toklist_print(self.tokens)
-                message = f"unrecognized directive '{spelling}'"
-                log.warning(f"{filename}:{line}:{column}: {message}")
             return UnrecognizedDirectiveNode(self.tokens)
         except ParseError:
             raise ParseError("Not a directive.")


### PR DESCRIPTION
The new warning message includes the line and column of the unrecognized directive, as well as spelling of the directive itself.

Neither the Token class nor the DirectiveParser class knows the filename, so this not included for now.