### PR TITLE
Permit include files with non-standard extensions

### DIFF
--- a/codebasin/file_parser.py
+++ b/codebasin/file_parser.py
@@ -126,7 +126,7 @@ class FileParser:
         new_node.num_lines = line_group.line_count
         tree.insert(new_node)
 
-    def parse_file(self, *, summarize_only=True):
+    def parse_file(self, *, summarize_only=True, language=None):
         """
         Parse the file that this parser points at, build a SourceTree
         representing this file, and return it.
@@ -134,7 +134,7 @@ class FileParser:
 
         filename = self._filename
         out_tree = preprocessor.SourceTree(filename)
-        file_source = get_file_source(filename)
+        file_source = get_file_source(filename, language)
         if not file_source:
             raise RuntimeError(f"{filename} doesn't appear " +
                                "to be a language this tool can process")

--- a/codebasin/file_source.py
+++ b/codebasin/file_source.py
@@ -679,7 +679,7 @@ def get_file_source(path, assumed_lang=None):
     the language we can detect, or fail.
     """
     lang = FileLanguage(path).get_language()
-    if not lang and assumed_lang:
+    if assumed_lang:
         lang = assumed_lang
 
     if lang == "fortran-free":

--- a/codebasin/file_source.py
+++ b/codebasin/file_source.py
@@ -6,7 +6,10 @@ C/C++ files as well as fixed-form Fortran
 """
 
 import itertools as it
+import logging
 from .language import FileLanguage
+
+log = logging.getLogger('codebasin')
 
 # This string was created by looking at all unicode code points
 # and checking to see if they are considered whitespace
@@ -670,18 +673,20 @@ def asm_file_source(fp, relaxed=False):
     return (total_sloc, total_physical_lines)
 
 
-def get_file_source(path):
+def get_file_source(path, assumed_lang=None):
     """
     Return a C or Fortran line source for path depending on
     the language we can detect, or fail.
     """
-    lang = FileLanguage(path)
-    if lang.get_language() == "fortran-free":
+    lang = FileLanguage(path).get_language()
+    if not lang and assumed_lang:
+        lang = assumed_lang
+
+    if lang == "fortran-free":
         return fortran_file_source
-    elif lang.get_language() in ["c", "c++"]:
+    elif lang in ["c", "c++"]:
         return c_file_source
-    elif lang.get_language() in ["asm"]:
+    elif lang in ["asm"]:
         return asm_file_source
     else:
-        raise RuntimeError(f"Language {lang.get_language()} in file " +
-                           f"{path} is unsupported by code base investigator")
+        raise RuntimeError(f"Could not determine language of {path}.")

--- a/codebasin/finder.py
+++ b/codebasin/finder.py
@@ -13,6 +13,7 @@ from . import file_parser
 from . import platform
 from . import preprocessor
 from . import util
+from .language import FileLanguage
 from .walkers.tree_associator import TreeAssociator
 
 log = logging.getLogger("codebasin")
@@ -40,6 +41,7 @@ class ParserState():
     def __init__(self, summarize_only):
         self.trees = {}
         self.maps = {}
+        self.langs = {}
         self.summarize_only = summarize_only
         self.fileinfo = collections.defaultdict(list)
         self.merge_duplicates = True
@@ -86,7 +88,7 @@ class ParserState():
         self.fileinfo[bn].append(FileInfo(fn, size, sha))
         return fn
 
-    def insert_file(self, fn):
+    def insert_file(self, fn, language=None):
         """
         Build a new tree for a source file, and create an association
         map for it.
@@ -94,8 +96,12 @@ class ParserState():
         fn = self._map_filename(fn)
         if fn not in self.trees:
             parser = file_parser.FileParser(fn)
-            self.trees[fn] = parser.parse_file(summarize_only=self.summarize_only)
+            self.trees[fn] = parser.parse_file(summarize_only=self.summarize_only, language=language)
             self.maps[fn] = collections.defaultdict(set)
+            if language:
+                self.langs[fn] = language
+            else:
+                self.langs[fn] = FileLanguage(fn).get_language()
 
     def get_filenames(self):
         """

--- a/codebasin/language.py
+++ b/codebasin/language.py
@@ -32,7 +32,7 @@ class FileLanguage:
     def __init__(self, filename):
         self._filename = filename
         self._extension = os.path.splitext(self._filename)[1]
-        self._language = 'None'
+        self._language = None
 
         for lang in self._supported_languages:
             if self._extension in self._language_extensions[lang]:

--- a/codebasin/preprocessor.py
+++ b/codebasin/preprocessor.py
@@ -838,7 +838,10 @@ class IncludeNode(DirectiveNode):
             include_path, this_path, is_system_include)
 
         if include_file and kwargs['platform'].process_include(include_file):
-            kwargs['state'].insert_file(include_file)
+            # include files use the same language as the file itself,
+            # irrespective of file extension.
+            lang = kwargs['state'].langs[kwargs['filename']]
+            kwargs['state'].insert_file(include_file, lang)
 
             associator = TreeAssociator(kwargs['state'].get_tree(
                 include_file), kwargs['state'].get_map(include_file))


### PR DESCRIPTION
Many projects include files with non-standard extensions like ".def" and ".inc". Others include files with no extension at all (e.g., in the case of C++ standard libraries).

This commit introduces functionality which tracks the language associated with each filename, allowing the preprocessor to propagate the expected language to any files encountered during the processing of #include directives.

The language of top-level source files is still determined by looking at the extension, as before.

Closes #14.