### PR TITLE
Add ability to recognize compilers

### DIFF
--- a/codebasin/config.py
+++ b/codebasin/config.py
@@ -334,7 +334,7 @@ class ClangCompiler(Compiler):
         for arg in args:
 
             if arg == "-fsycl":
-                sycl = True
+                self.sycl = True
                 continue
 
             m = re.search("-fsycl-targets=", arg)

--- a/codebasin/config.py
+++ b/codebasin/config.py
@@ -378,6 +378,11 @@ class GnuCompiler(Compiler):
     def __init__(self, args):
         super().__init__(args)
 
+        for arg in args:
+            if arg in ["-fopenmp"]:
+                self.defines.append("_OPENMP")
+                break
+
 
 class HipCompiler(Compiler):
     """

--- a/codebasin/config.py
+++ b/codebasin/config.py
@@ -409,11 +409,16 @@ class NvccCompiler(Compiler):
 
     def __init__(self, args):
         super().__init__(args)
+        self.omp = False
 
         for arg in args:
             archs = re.findall("sm_(\\d+)", arg)
             archs += re.findall("compute_(\\d+)", arg)
             self.passes |= set(archs)
+
+            if arg in ["-fopenmp", "-fiopenmp", "-qopenmp"]:
+                self.omp = True
+                continue
 
     def get_defines(self, pass_):
         defines = super().get_defines(pass_)
@@ -424,6 +429,9 @@ class NvccCompiler(Compiler):
         if pass_ != "default":
             arch = int(pass_) * 10
             defines.append(f"__CUDA_ARCH__={arch}")
+
+        if pass_ == "default" and self.omp:
+            defines.append("_OPENMP")
 
         return defines
 

--- a/codebasin/config.py
+++ b/codebasin/config.py
@@ -512,15 +512,16 @@ def recognize_compiler(args):
         compiler = IntelCompiler(args)
     elif compiler_name == "nvcc":
         compiler = NvccCompiler(args)
-
-    if compiler:
-        log.info(f"Recognized compiler: {compiler.name}.")
     else:
         compiler = Compiler(args)
-        if not _seen_compiler[compiler_name]:
+
+    if not _seen_compiler[compiler_name]:
+        if compiler:
+            log.info(f"Recognized compiler: {compiler.name}.")
+        else:
             log.warning(f"Unrecognized compiler: {compiler_name}. " +
                         "Some implicit behavior may be missed.")
-            _seen_compiler[compiler_name] = True
+        _seen_compiler[compiler_name] = True
     return compiler
 
 

--- a/codebasin/config.py
+++ b/codebasin/config.py
@@ -432,7 +432,7 @@ def recognize_compiler(args):
     compiler_name = os.path.basename(args[0])
     if compiler_name in ["clang", "clang++"]:
         compiler = ClangCompiler(args)
-    elif compiler_name in ["gcc", "gxx"]:
+    elif compiler_name in ["gcc", "g++"]:
         compiler = GnuCompiler(args)
     elif compiler_name in ["hipcc"]:
         compiler = HipCompiler(args)

--- a/codebasin/config.py
+++ b/codebasin/config.py
@@ -428,6 +428,7 @@ class NvccCompiler(Compiler):
         return defines
 
 
+_seen_compiler = collections.defaultdict(lambda: False)
 def recognize_compiler(args):
     """
     Attempt to recognize the compiler, given an argument list.
@@ -450,8 +451,10 @@ def recognize_compiler(args):
         log.info(f"Recognized compiler: {compiler.name}.")
     else:
         compiler = Compiler(args)
-        log.warning(f"Unrecognized compiler: {compiler_name}. " +
-                    "Some implicit behavior may be missed.")
+        if not _seen_compiler[compiler_name]:
+            log.warning(f"Unrecognized compiler: {compiler_name}. " +
+                        "Some implicit behavior may be missed.")
+            _seen_compiler[compiler_name] = True
     return compiler
 
 

--- a/codebasin/schema/importcfg.schema
+++ b/codebasin/schema/importcfg.schema
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/intel/code-base-investigator/schema/importcfg.schema",
+  "title": "Code Base Investigator Import Configuration File",
+  "description": "Configuration options for importing commands.",
+  "type": "object",
+  "properties": {
+    "compilers": {
+      "type": "array",
+      "items": {
+        "type": "object",
+        "properties": {
+          "name": {
+            "type": "string",
+          },
+          "options": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": ["name", "options"],
+        "additionalProperties": false,
+      }
+    }
+  },
+  "required": ["compilers"],
+  "additionalProperties": false
+}

--- a/tests/compilers/__init__.py
+++ b/tests/compilers/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2019-2023 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause

--- a/tests/compilers/test_compilers.py
+++ b/tests/compilers/test_compilers.py
@@ -1,0 +1,99 @@
+# Copyright (C) 2019-2023 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+
+import unittest
+import logging
+from codebasin import config
+
+class TestCompilers(unittest.TestCase):
+    """
+    Test that a subset of common compilers and their arguments are recognized
+    correctly, and that any implicit behavior(s) are activated.
+    """
+
+    def setUp(self):
+        logging.getLogger("codebasin").disabled = True
+
+    def test_clang(self):
+        """compilers/clang"""
+        args = [
+            "clang",
+            "-fsycl-is-device",
+            "test.cpp"
+        ]
+
+        compiler = config.recognize_compiler(args)
+        self.assertTrue(type(compiler) is config.ClangCompiler)
+
+        passes = compiler.get_passes()
+        self.assertEqual(passes, set(["default"]))
+
+        self.assertTrue(compiler.has_implicit_behavior("default"))
+        defines = compiler.get_defines("default")
+        self.assertEqual(defines, ["__SYCL_DEVICE_ONLY__"])
+
+    def test_intel(self):
+        """compilers/intel"""
+        args = [
+            "icpx",
+            "-fsycl",
+            "-fsycl-targets=spir64,x86_64",
+            "-fopenmp",
+            "test.cpp"
+        ]
+
+        compiler = config.recognize_compiler(args)
+        self.assertTrue(type(compiler) is config.IntelCompiler)
+
+        passes = compiler.get_passes()
+        self.assertEqual(passes, set(["default", "spir64", "x86_64"]))
+
+        self.assertTrue(compiler.has_implicit_behavior("default"))
+        defines = compiler.get_defines("default")
+        self.assertEqual(defines, ["_OPENMP"])
+
+        expected = [
+            "__SYCL_DEVICE_ONLY__",
+            "__SPIR__",
+            "__SPIRV__"
+        ]
+        self.assertTrue(compiler.has_implicit_behavior("spir64"))
+        defines = compiler.get_defines("spir64")
+        self.assertEqual(defines, expected)
+        self.assertTrue(compiler.has_implicit_behavior("x86_64"))
+        defines = compiler.get_defines("x86_64")
+        self.assertEqual(defines, expected)
+
+    def test_nvcc(self):
+        """compilers/nvcc"""
+        args = [
+            "nvcc",
+            "--gpu-architecture=compute_50",
+            "--gpu-code=compute_50,sm_50,sm_52",
+            "test.cpp"
+        ]
+
+        compiler = config.recognize_compiler(args)
+        self.assertTrue(type(compiler) is config.NvccCompiler)
+
+        passes = compiler.get_passes()
+        self.assertEqual(passes, set(["default", "50", "52"]))
+
+        defaults = [
+            "__NVCC__",
+            "__CUDACC__"
+        ]
+        self.assertTrue(compiler.has_implicit_behavior("default"))
+        defines = compiler.get_defines("default")
+        self.assertEqual(defines, defaults)
+
+        self.assertTrue(compiler.has_implicit_behavior("50"))
+        defines = compiler.get_defines("50")
+        self.assertEqual(defines, defaults + ["__CUDA_ARCH__=500"])
+
+        self.assertTrue(compiler.has_implicit_behavior("52"))
+        defines = compiler.get_defines("52")
+        self.assertEqual(defines, defaults + ["__CUDA_ARCH__=520"])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/compilers/test_compilers.py
+++ b/tests/compilers/test_compilers.py
@@ -32,8 +32,31 @@ class TestCompilers(unittest.TestCase):
         defines = compiler.get_defines("default")
         self.assertEqual(defines, ["__SYCL_DEVICE_ONLY__"])
 
-    def test_intel(self):
-        """compilers/intel"""
+    def test_intel_sycl(self):
+        """compilers/intel_sycl"""
+        args = [
+            "icpx",
+            "-fsycl",
+            "test.cpp"
+        ]
+
+        compiler = config.recognize_compiler(args)
+        self.assertTrue(type(compiler) is config.IntelCompiler)
+
+        passes = compiler.get_passes()
+        self.assertEqual(passes, set(["default", "spir64"]))
+
+        expected = [
+            "__SYCL_DEVICE_ONLY__",
+            "__SPIR__",
+            "__SPIRV__"
+        ]
+        self.assertTrue(compiler.has_implicit_behavior("spir64"))
+        defines = compiler.get_defines("spir64")
+        self.assertEqual(defines, expected)
+
+    def test_intel_targets(self):
+        """compilers/intel_targets"""
         args = [
             "icpx",
             "-fsycl",


### PR DESCRIPTION
This ended up being more work than I anticipated, as the fix for #15 is quite complicated.

There are three components to the solution in this PR:

1. When CBI encounters a compilation command in a compilation database, it checks the name of the command against a known list of compiler behaviors.

2. The built-in list of compiler behaviors has support for implicit defines, include paths and include files (although only the defines are used). Additionally, these implicit behaviors are broken into different passes, accounting for the fact that commands like `icpx -fsycl` and `nvcc` will compile both host and device code with different macros set.
 
3. The user can define additional behavior (currently limited to defines) via a new `.cbi/importcfg.json` file. This allows users to define macros we can't reason about (like `__CUDACC_VER_MAJOR__`) and to define the behavior of tools we don't support.

I wanted to limit the scope of this first version of the feature and get it committed for 1.2.0.  But I suspect that we will need to revisit and expand this feature multiple times, as compilers add new options and users request new compilers.

Ultimately, we may want to shift towards a solution where all of the built-in compiler behaviors can be described via the `.cbi/importcfg.json` file, since this may be more extensible.