### PR TITLE
Fix codebasin package

### DIFF
--- a/codebasin/walkers/__init__.py
+++ b/codebasin/walkers/__init__.py
@@ -1,3 +1,2 @@
 # Copyright (C) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
-import codebasin.walkers

--- a/setup.py
+++ b/setup.py
@@ -5,12 +5,12 @@
 from setuptools import setup
 
 setup(name='codebasin',
-      version='1.05',
+      version='1.1.0',
       description='Code Base Investigator',
       author='John Pennycook',
       author_email='john.pennycook@intel.com',
       url='https://www.github.com/intel/code-base-investigator',
-      packages=['codebasin'],
+      packages=['codebasin', 'codebasin.walkers'],
       scripts=['codebasin.py'],
       classifiers=['Development Status :: 3 - Alpha',
                    'Environment :: Console',


### PR DESCRIPTION
- Imports codebasin.walkers into codebasin
- Adds `__init__.py` to the codebasin/walkers/ subpackage
- Adds walkers subpackage to setup.py
- Sets the correct version in setup.py

----

With these changes, it's possible to `pip install` the `codebasin` package and then write Python scripts that depend on it. 🥳 