### PR TITLE
Fix bug in multi-pass compiler handling

### DIFF
--- a/codebasin/config.py
+++ b/codebasin/config.py
@@ -594,9 +594,9 @@ def load_database(dbpath, rootdir):
         if os.path.exists(path):
             for pass_ in compiler.get_passes():
                 entry = {"file": path,
-                         "defines": defines,
-                         "include_paths": include_paths,
-                         "include_files": include_files}
+                         "defines": defines.copy(),
+                         "include_paths": include_paths.copy(),
+                         "include_files": include_files.copy()}
                 if compiler.has_implicit_behavior(pass_):
                     extra_flags = []
                     compiler_config = compiler.get_configuration(pass_)


### PR DESCRIPTION
Prior to this commit, the same list was being used to construct the compilation database entries for each pass of a multi-pass compiler. As a result, any modifications to the list were incorrectly shared across passes.