### PR TITLE
Fix incorrect usage of _representation_string

### DIFF
--- a/codebasin/preprocessor.py
+++ b/codebasin/preprocessor.py
@@ -626,7 +626,7 @@ class FileNode(Node):
         return parent_json
 
     def __repr__(self):
-        return _representation_string(self, attrs="filename")
+        return _representation_string(self, attrs=["filename"])
 
     def __str__(self):
         return f"{str(self.filename)}; Hash: {str(self.file_hash)}"


### PR DESCRIPTION
Because a string is iterable, passing "filename" directly as the "attrs" is interpreted as a request to print "f", "i", ... and so on.

We missed this in review and it's not currently covered by any tests.  Finding this bug is what led me to open #36.