### PR TITLE
Deprecate the codebasin package

### DIFF
--- a/codebasin/__init__.py
+++ b/codebasin/__init__.py
@@ -1,3 +1,13 @@
 # Copyright (C) 2019-2024 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
+import warnings
+
 import codebasin.walkers
+
+warnings.warn(
+    "Calling codebasin package internals is deprecated. "
+    + "Please call the codebasin script directly instead. "
+    + "A new, stable, package interface will be introduced in "
+    + "a future release of Code Base Investigator.",
+    DeprecationWarning,
+)


### PR DESCRIPTION
The codebasin package was not originally designed for downstream users: the interface is undocumented, and in many cases is not very user-friendly.

Semantic versioning recommends that there be at least one minor release with a deprecation warning prior to removing functionality in a major release. Deprecating the entire package is a simple solution that accurately communicates our intent to users.