### PR TITLE
Add support for exclude patterns

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ The distances can also be used to produce a dendrogram, showing the result of hi
 - jsonschema
 - Matplotlib
 - NumPy
+- pathspec
 - Python 3
 - PyYAML
 - SciPy

--- a/codebasin.py
+++ b/codebasin.py
@@ -113,10 +113,11 @@ if __name__ == "__main__":
         "-x",
         "--exclude",
         dest="excludes",
-        metavar="<pathspec>",
+        metavar="<pattern>",
         action="append",
         default=[],
-        help="paths to exclude from the codebase",
+        help="Exclude files matching this pattern from the code base. "
+        + "May be specified multiple times.",
     )
     args = parser.parse_args()
 

--- a/codebasin.py
+++ b/codebasin.py
@@ -109,6 +109,15 @@ if __name__ == "__main__":
         default=False,
         help="Set batch mode (additional output for bulk operation.)",
     )
+    parser.add_argument(
+        "-x",
+        "--exclude",
+        dest="excludes",
+        metavar="<pathspec>",
+        action="append",
+        default=[],
+        help="paths to exclude from the codebase",
+    )
     args = parser.parse_args()
 
     stdout_log = logging.StreamHandler(sys.stdout)
@@ -129,7 +138,11 @@ if __name__ == "__main__":
             "Configuration file does not have YAML file extension.",
         )
         sys.exit(1)
-    codebase, configuration = config.load(config_file, rootdir)
+    codebase, configuration = config.load(
+        config_file,
+        rootdir,
+        exclude_patterns=args.excludes,
+    )
 
     # Parse the source tree, and determine source line associations.
     # The trees and associations are housed in state.

--- a/codebasin/config.py
+++ b/codebasin/config.py
@@ -103,7 +103,7 @@ def flatten(nested_list):
     return flattened
 
 
-def load_codebase(config, rootdir):
+def load_codebase(config, rootdir, *, exclude_patterns=None):
     """
     Load the code base definition into a Python object.
     Return a dict of files and platform names.
@@ -142,6 +142,9 @@ def load_codebase(config, rootdir):
         codebase["exclude_patterns"] = cfg_codebase["exclude_patterns"]
     else:
         codebase["exclude_patterns"] = []
+
+    if exclude_patterns:
+        codebase["exclude_patterns"] += exclude_patterns
 
     if cfg_codebase["files"]:
         codebase["files"] = list(
@@ -568,7 +571,7 @@ def load_platform(config, rootdir, platform_name):
     return configuration
 
 
-def load(config_file, rootdir):
+def load(config_file, rootdir, *, exclude_patterns=None):
     """
     Load the configuration file into Python objects.
     Return a (codebase, platform configuration) tuple of dicts.
@@ -584,7 +587,11 @@ def load(config_file, rootdir):
 
     # Read codebase definition
     if "codebase" in config:
-        codebase = load_codebase(config, rootdir)
+        codebase = load_codebase(
+            config,
+            rootdir,
+            exclude_patterns=exclude_patterns,
+        )
     else:
         raise RuntimeError("Missing 'codebase' section in config file!")
 

--- a/codebasin/config.py
+++ b/codebasin/config.py
@@ -12,6 +12,7 @@ import logging
 import os
 import re
 import shlex
+import warnings
 
 import yaml
 
@@ -131,8 +132,16 @@ def load_codebase(config, rootdir):
                 ),
             ),
         )
+        warnings.warn(
+            "'exclude_files' is deprecated. Use 'exclude_pattern' instead.",
+        )
     else:
         codebase["exclude_files"] = frozenset([])
+
+    if "exclude_patterns" in cfg_codebase:
+        codebase["exclude_patterns"] = cfg_codebase["exclude_patterns"]
+    else:
+        codebase["exclude_patterns"] = []
 
     if cfg_codebase["files"]:
         codebase["files"] = list(

--- a/codebasin/schema/config.schema
+++ b/codebasin/schema/config.schema
@@ -25,6 +25,12 @@
           "items": {
             "type": "string"
           }
+        },
+        "exclude_patterns": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
         }
       },
       "required": [

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ setup(
     install_requires=[
         "numpy",
         "matplotlib",
+        "pathspec",
         "pyyaml",
         "scipy>=1.11.1",
         "jsonschema",

--- a/tests/exclude/__init__.py
+++ b/tests/exclude/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2019-2024 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause

--- a/tests/exclude/commands.json
+++ b/tests/exclude/commands.json
@@ -1,0 +1,18 @@
+[
+  {
+    "command": "/usr/bin/g++ included.cpp",
+    "file": "src/included.cpp"
+  },
+  {
+    "command": "/usr/bin/g++ excluded_name.cpp",
+    "file": "src/excluded_name.cpp"
+  },
+  {
+    "command": "/usr/bin/gfortran excluded_extension.f90",
+    "file": "src/excluded_extension.f90"
+  },
+  {
+    "command": "/usr/bin/g++ library.cpp",
+    "file": "src/thirdparty/library.cpp"
+  }
+]

--- a/tests/exclude/exclude.yaml
+++ b/tests/exclude/exclude.yaml
@@ -1,0 +1,6 @@
+codebase:
+    files: [ ]
+    platforms: [ test ]
+
+test:
+    commands: "commands.json"

--- a/tests/exclude/src/excluded_extension.f90
+++ b/tests/exclude/src/excluded_extension.f90
@@ -1,0 +1,1 @@
+#define EXCLUDED_EXTENSION

--- a/tests/exclude/src/excluded_name.cpp
+++ b/tests/exclude/src/excluded_name.cpp
@@ -1,0 +1,1 @@
+#define EXCLUDED_NAME

--- a/tests/exclude/src/included.cpp
+++ b/tests/exclude/src/included.cpp
@@ -1,0 +1,1 @@
+#define INCLUDED

--- a/tests/exclude/src/thirdparty/library.cpp
+++ b/tests/exclude/src/thirdparty/library.cpp
@@ -1,0 +1,1 @@
+#define THIRDPARTY_LIBRARY

--- a/tests/exclude/test_exclude.py
+++ b/tests/exclude/test_exclude.py
@@ -1,0 +1,66 @@
+# Copyright (C) 2019 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+
+import logging
+import unittest
+
+from codebasin import config, finder
+from codebasin.walkers.platform_mapper import PlatformMapper
+
+
+class TestExclude(unittest.TestCase):
+    """
+    Simple test of ability to exclude files using patterns.
+    """
+
+    def setUp(self):
+        self.rootdir = "./tests/exclude/"
+        logging.getLogger("codebasin").disabled = True
+
+    def _get_setmap(self, excludes):
+        codebase, configuration = config.load(
+            "./tests/exclude/exclude.yaml",
+            self.rootdir,
+            exclude_patterns=excludes,
+        )
+        state = finder.find(self.rootdir, codebase, configuration)
+        mapper = PlatformMapper(codebase)
+        setmap = mapper.walk(state)
+        return setmap
+
+    def test_exclude_nothing(self):
+        """exclude/nothing"""
+        excludes = []
+        setmap = self._get_setmap(excludes)
+        expected_setmap = {frozenset(["test"]): 4}
+        self.assertDictEqual(setmap, expected_setmap, "Mismatch in setmap")
+
+    def test_exclude_extension(self):
+        """exclude/extension"""
+        excludes = ["*.f90"]
+        setmap = self._get_setmap(excludes)
+        expected_setmap = {frozenset(["test"]): 3}
+        self.assertDictEqual(setmap, expected_setmap, "Mismatch in setmap")
+
+    def test_exclude_name(self):
+        """exclude/name"""
+        excludes = ["src/excluded_name.cpp"]
+        setmap = self._get_setmap(excludes)
+        expected_setmap = {frozenset(["test"]): 3}
+        self.assertDictEqual(setmap, expected_setmap, "Mismatch in setmap")
+
+    def test_excluded_directory(self):
+        excludes = ["thirdparty/"]
+        setmap = self._get_setmap(excludes)
+        expected_setmap = {frozenset(["test"]): 3}
+        self.assertDictEqual(setmap, expected_setmap, "Mismatch in setmap")
+
+    def test_excludes(self):
+        excludes = ["*.f90", "src/excluded_name.cpp", "thirdparty/"]
+        setmap = self._get_setmap(excludes)
+        expected_setmap = {frozenset(["test"]): 1}
+        self.assertDictEqual(setmap, expected_setmap, "Mismatch in setmap")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/exclude/test_exclude.py
+++ b/tests/exclude/test_exclude.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019 Intel Corporation
+# Copyright (C) 2019-2024 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 import logging


### PR DESCRIPTION
`exclude_patterns` replaces the `exclude_files` option, allowing the use of git-style "pathspec"s in place of globs. This may seem like a small change, but it's very powerful, allowing patterns as simple as "*.ext" to exclude ALL files with a particular extension.

This PR also adds a `--exclude` option to the codebasin script that exposes the same functionality without having to modify the YAML configuration file, which is both more convenient and more aligned with our long-term direction.

The functionality here is 99% of the work for supporting a `.cbiignore` file in the source directory (which basically acts as an implicit list of exclude patterns) but I wanted to keep that separate to simplify review of the base functionality.