### PR TITLE
Templates for pull requests and issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,34 @@
+name: 🐛 Bug report
+description: Create a report to help us improve
+labels: bug
+title: "[Bug]: "
+
+body:
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected behavior
+      description: What did you expect to happen?
+    validations:
+      required: true
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual behavior
+      description: Paste the stack trace, screen clips of the problem, etc.
+    validations:
+      required: true
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce the problem
+      description: Enumerate and/or describe the steps to reproduce this problem.
+    validations:
+      required: true
+  - type: textarea
+    id: specifications
+    attributes:
+      label: Specifications
+      description: What version of the package are you using, and on what kind of hardware/software environment? Please consider including the output of `pip freeze` here.
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,7 +1,6 @@
 name: 🐛 Bug report
 description: Create a report to help us improve
 labels: bug
-title: "[Bug]: "
 
 body:
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: false
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,38 @@
+name: 🚀 Feature request
+description: Suggest new functionality
+labels: enhancement
+title: "[Feature request]: "
+body:
+  - type: textarea
+    validations:
+      required: true
+    attributes:
+      label: Feature/behavior summary
+      description: Describe your feature or desired package behavior succinctly.
+  - type: checkboxes
+    validations:
+      required: true
+    attributes:
+      label: Request attributes
+      options:
+        - label: Would this be a refactor of existing code?
+        - label: Does this proposal require new package dependencies?
+        - label: Would this change break backwards compatibility?
+  - type: textarea
+    validations:
+      required: false
+    attributes:
+      label: Related issues
+      description: Is your feature request related to any issue(s)? If so, please provide the issue number(s).
+  - type: textarea
+    validations:
+      required: true
+    attributes:
+      label: Solution description
+      description: Describe solution(s) to the problem. Write "Unknown" if you haven't identified a solution.
+  - type: textarea
+    validations:
+      required: false
+    attributes:
+      label: Additional notes
+      description: Any additional context, screenshots, etc. that may help with the discussion and implementation.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,7 +1,6 @@
 name: 🚀 Feature request
 description: Suggest new functionality
 labels: enhancement
-title: "[Feature request]: "
 body:
   - type: textarea
     validations:

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,16 @@
+# Related issues
+
+If applicable:
+
+Closes/Fixes/Addresses #<issue_number>
+
+If not applicable: write "N/A".
+
+# Proposed changes
+
+List out&mdash;with high level descriptions&mdash;what the commits
+within this PR do:
+
+-
+-
+-


### PR DESCRIPTION
This PR ports template files and configurations from the sister P3 analysis library, which provides schema for submitting pull requests and creating issues for either bug reports or feature requests. Additionally, `config.yml` now specifies that empty issues are no longer permitted.