### PR TITLE
Reformat usage string

### DIFF
--- a/codebasin.py
+++ b/codebasin.py
@@ -66,7 +66,7 @@ if __name__ == "__main__":
         dest="config_file",
         metavar="FILE",
         action="store",
-        help="configuration file (default: <DIR>/config.yaml)",
+        help="Configuration file (default: <DIR>/config.yaml)",
     )
     parser.add_argument(
         "-v",
@@ -74,7 +74,7 @@ if __name__ == "__main__":
         dest="verbose",
         action="count",
         default=0,
-        help="increase verbosity level",
+        help="Increase verbosity level",
     )
     parser.add_argument(
         "-q",
@@ -82,7 +82,7 @@ if __name__ == "__main__":
         dest="quiet",
         action="count",
         default=0,
-        help="decrease verbosity level",
+        help="Decrease verbosity level",
     )
     parser.add_argument(
         "-R",
@@ -92,7 +92,7 @@ if __name__ == "__main__":
         default=["all"],
         choices=["all", "summary", "clustering"],
         nargs="+",
-        help="desired output reports (default: all)",
+        help="Desired output reports (default: all)",
     )
     parser.add_argument(
         "-d",
@@ -100,7 +100,7 @@ if __name__ == "__main__":
         dest="dump",
         metavar="<file.json>",
         action="store",
-        help="dump out annotated platform/parsing tree to <file.json>",
+        help="Dump out annotated platform/parsing tree to <file.json>",
     )
     parser.add_argument(
         "--batchmode",

--- a/codebasin.py
+++ b/codebasin.py
@@ -50,6 +50,16 @@ if __name__ == "__main__":
     # Read command-line arguments
     parser = argparse.ArgumentParser(
         description="Code Base Investigator v" + str(version),
+        formatter_class=argparse.RawTextHelpFormatter,
+        add_help=False,
+    )
+
+    parser.add_argument(
+        "-h",
+        "--help",
+        action="help",
+        default=argparse.SUPPRESS,
+        help="\nShow this message and exit",
     )
     parser.add_argument(
         "-r",
@@ -74,7 +84,7 @@ if __name__ == "__main__":
         dest="verbose",
         action="count",
         default=0,
-        help="Increase verbosity level",
+        help="\nIncrease verbosity level",
     )
     parser.add_argument(
         "-q",
@@ -82,7 +92,7 @@ if __name__ == "__main__":
         dest="quiet",
         action="count",
         default=0,
-        help="Decrease verbosity level",
+        help="\nDecrease verbosity level",
     )
     parser.add_argument(
         "-R",
@@ -107,7 +117,7 @@ if __name__ == "__main__":
         dest="batchmode",
         action="store_true",
         default=False,
-        help="Set batch mode (additional output for bulk operation.)",
+        help="\nSet batch mode (additional output for bulk operation.)",
     )
     parser.add_argument(
         "-x",
@@ -116,7 +126,7 @@ if __name__ == "__main__":
         metavar="<pattern>",
         action="append",
         default=[],
-        help="Exclude files matching this pattern from the code base. "
+        help="Exclude files matching this pattern from the code base."
         + "May be specified multiple times.",
     )
     args = parser.parse_args()


### PR DESCRIPTION
# Related issues

If applicable: N/A

Closes/Fixes/Addresses #<45>

If not applicable: write "N/A".

# Proposed changes

List out&mdash;with high level descriptions&mdash;what the commits
within this PR do:

- Reformat usage string to contain newline between argument and description
- Consistently formats all usage string descriptions to start with capital letter
