### PR TITLE
Adjust pull request template formatting

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,15 +1,22 @@
 # Related issues
 
-If applicable:
+<!--
+If applicable, provide a list of related issues here.
 
-Closes/Fixes/Addresses #<issue_number>
+Consider using a keyword like "closes" to automatically link this pull request
+to any issues that should be automatically closed when this pull request is
+merged. See the GitHub documentation for more information:
+https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests
 
-If not applicable: write "N/A".
+If not applicable, write "N/A".
+-->
 
 # Proposed changes
 
-List out&mdash;with high level descriptions&mdash;what the commits
-within this PR do:
+<!--
+List out, with high level descriptions, what the commits within this pull
+request do.
+-->
 
 -
 -


### PR DESCRIPTION
Moves the instructions into comments. This will prevent instructions from being included in created pull requests (unless somebody uncomments them), and gives us the freedom to expand upon the instructions (e.g., by including links).

# Related issues

N/A

# Proposed changes

- Make PR template instructions into comments.
- Add a link to the GitHub documentation for closing keywords.
- Remove the `&mdash;` to make the comments human-readable (since we're not going to display them anywhere).
