### PR TITLE
Remove flake8-bandit from pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -49,7 +49,6 @@ repos:
       - id: flake8
         additional_dependencies:
           [
-            flake8-bandit,
             flake8-debugger,
             flake8-use-fstring,
           ]


### PR DESCRIPTION
flake8-bandit expects a .bandit file in TOML format, whereas bandit itself expects a bandit configuration file. This conflict results in an error.

Since we're already running bandit, we don't need to run flake8-bandit as well.

# Related issues

<!--
If applicable, provide a list of related issues here.

Consider using a keyword like "closes" to automatically link this pull request
to any issues that should be automatically closed when this pull request is
merged. See the GitHub documentation for more information:
https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests

If not applicable, write "N/A".
-->

N/A

# Proposed changes

<!--
List out, with high level descriptions, what the commits within this pull
request do.
-->

- Removes flake8-bandit from pre-commit.