### PR TITLE
Restore missing {} to report outputs

### DIFF
--- a/codebasin/report.py
+++ b/codebasin/report.py
@@ -102,7 +102,7 @@ def summary(setmap):
     data = []
     total_count = 0
     for pset in sorted(setmap.keys(), key=len):
-        name = ", ".join(pset)
+        name = "{" + ", ".join(pset) + "}"
         count = setmap[pset]
         percent = (float(setmap[pset]) / float(total)) * 100
         data += [[name, str(count), f"{percent:.2f}"]]


### PR DESCRIPTION
Previous versions of CBI used {} to denote sets, for example:
- {} for the empty set (unused code)
- {CPU, GPU} for the set containing both CPU and GPU

When we upgraded to f-strings these braces were accidentally removed.

# Related issues

N/A

# Proposed changes

- Surround set names with "{}" in report output.
