### PR TITLE
Replace YAML config files with TOML analysis files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
+include codebasin/schema/analysis.schema
 include codebasin/schema/compilation-database.schema
 include codebasin/schema/config.schema
 include codebasin/schema/coverage-0.1.0.schema

--- a/bin/codebasin
+++ b/bin/codebasin
@@ -260,6 +260,8 @@ def main():
             codebase["exclude_patterns"] += excludes
 
         for name in analysis_toml["platform"].keys():
+            if filtered_platforms and name not in filtered_platforms:
+                continue
             if "commands" not in analysis_toml["platform"][name]:
                 raise ValueError(f"Missing 'commands' for platform {name}")
             p = analysis_toml["platform"][name]["commands"]

--- a/bin/codebasin
+++ b/bin/codebasin
@@ -64,9 +64,9 @@ def main():
         "-c",
         "--config",
         dest="config_file",
-        metavar="FILE",
+        metavar="<config-file>",
         action="store",
-        help="configuration file (default: <DIR>/config.yaml)",
+        help="Configuration YAML file. " + "Defaults to config.yaml",
     )
     parser.add_argument(
         "-v",
@@ -131,6 +131,14 @@ def main():
         + "May be specified multiple times. "
         + "If not specified, all known platforms will be included.",
     )
+    # The analysis-file argument is optional while we support the -c option.
+    parser.add_argument(
+        "analysis_file",
+        metavar="<analysis-file>",
+        nargs="?",
+        help="TOML file describing the analysis to be performed,"
+        + "including the codebase and platform descriptions.",
+    )
 
     args = parser.parse_args()
 
@@ -170,6 +178,11 @@ def main():
         rootpath = args.rootdir
     rootdir = os.path.realpath(rootpath)
 
+    if args.config_file and args.analysis_file:
+        raise RuntimeError(
+            "Cannot use --config (-c) with TOML analysis files.",
+        )
+
     # Process the -p flag first to infer wider context.
     filtered_platforms = []
     additional_platforms = []
@@ -189,9 +202,14 @@ def main():
             )
         filtered_platforms.append(p)
 
-    # If no additional platforms are specified, a config file is required.
+    # A legacy config file is required if:
+    # - No additional platforms are specified; or
+    # - No TOML analysis file is specified
     config_file = args.config_file
-    if len(additional_platforms) == 0 and config_file is None:
+    config_required = (
+        len(additional_platforms) == 0 and args.analysis_file is None
+    )
+    if config_file is None and config_required:
         config_file = os.path.join(rootdir, "config.yaml")
         if not os.path.exists(config_file):
             raise RuntimeError(f"Could not find config file {config_file}")
@@ -208,6 +226,10 @@ def main():
 
     # Load the configuration file if it exists, obeying any platform filter.
     if config_file is not None:
+        warnings.warn(
+            "YAML configuration files are deprecated. "
+            + "Use TOML analysis files instead.",
+        )
         if not util.ensure_yaml(config_file):
             logging.getLogger("codebasin").error(
                 "Configuration file does not have YAML file extension.",
@@ -219,6 +241,30 @@ def main():
             exclude_patterns=args.excludes,
             filtered_platforms=filtered_platforms,
         )
+
+    # Load the analysis file if it exists.
+    if args.analysis_file is not None:
+        path = os.path.realpath(args.analysis_file)
+        if os.path.exists(path):
+            if not os.path.splitext(path)[1] == ".toml":
+                raise RuntimeError(f"Analysis file {p} must end in .toml.")
+
+        with util.safe_open_read_nofollow(path, "rb") as f:
+            try:
+                analysis_toml = util._load_toml(f, "analysis")
+            except BaseException:
+                raise ValueError("Analysis file failed validation")
+
+        if "exclude" in analysis_toml["codebase"]:
+            excludes = analysis_toml["codebase"]["exclude"]
+            codebase["exclude_patterns"] += excludes
+
+        for name in analysis_toml["platform"].keys():
+            if "commands" not in analysis_toml["platform"][name]:
+                raise ValueError(f"Missing 'commands' for platform {name}")
+            p = analysis_toml["platform"][name]["commands"]
+            db = config.load_database(p, rootdir)
+            configuration.update({name: db})
 
     # Extend configuration with any additional platforms.
     for p in additional_platforms:

--- a/bin/codebasin
+++ b/bin/codebasin
@@ -210,6 +210,7 @@ def main():
         len(additional_platforms) == 0 and args.analysis_file is None
     )
     if config_file is None and config_required:
+        warnings.warn("Implicitly defined configuration files are deprecated.")
         config_file = os.path.join(rootdir, "config.yaml")
         if not os.path.exists(config_file):
             raise RuntimeError(f"Could not find config file {config_file}")

--- a/bin/codebasin
+++ b/bin/codebasin
@@ -203,7 +203,7 @@ def main():
         filtered_platforms.append(p)
 
     # A legacy config file is required if:
-    # - No additional platforms are specified; or
+    # - No additional platforms are specified; and
     # - No TOML analysis file is specified
     config_file = args.config_file
     config_required = (

--- a/codebasin/schema/analysis.schema
+++ b/codebasin/schema/analysis.schema
@@ -1,0 +1,35 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/intel/code-base-investigator/main/codebasin/schema/analysis.schema",
+  "title": "Code Base Investigator Analysis File",
+  "description": "Analysis options for Code Base Investigator.",
+  "type": "object",
+  "properties": {
+    "codebase": {
+      "type": "object",
+      "properties": {
+        "exclude": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    },
+    "platform": {
+      "type": "object",
+      "patternProperties": {
+        ".*": {
+          "type": "object",
+          "properties": {
+            "commands": {
+              "type": "string"
+            }
+          },
+          "additionalProperties": false
+        }
+      }
+    },
+    "additionalProperties": false
+  }
+}

--- a/codebasin/util.py
+++ b/codebasin/util.py
@@ -123,7 +123,7 @@ def _validate_json(json_object: object, schema_name: str) -> bool:
     json_object : Object
         The JSON to validate.
 
-    schema_name : {'compiledb', 'config', 'coverage', 'cbiconfig'}
+    schema_name : {'compiledb', 'config', 'coverage', 'cbiconfig', 'analysis'}
         The schema to validate against.
 
     Returns
@@ -140,6 +140,7 @@ def _validate_json(json_object: object, schema_name: str) -> bool:
         If the schema file cannot be located.
     """
     schema_paths = {
+        "analysis": "schema/analysis.schema",
         "compiledb": "schema/compilation-database.schema",
         "config": "schema/config.schema",
         "coverage": "schema/coverage-0.1.0.schema",
@@ -270,18 +271,18 @@ def _load_toml(file_object: typing.TextIO, schema_name: str) -> object:
     file_object : typing.TextIO
         The file object to load from.
 
-    schema_name : {'cbiconfig'}
+    schema_name : {'cbiconfig', 'analysis'}
         The schema to validate against.
 
     Returns
     -------
     Object
-        The loaded JSON.
+        The loaded TOML.
 
     Raises
     ------
     ValueError
-        If the JSON fails to validate, or the schema name is unrecognized.
+        If the TOML fails to validate, or the schema name is unrecognized.
 
     RuntimeError
         If the schema file cannot be located.

--- a/tests/schema/analysis.toml
+++ b/tests/schema/analysis.toml
@@ -1,0 +1,11 @@
+[codebase]
+exclude = [
+    "*.F90",
+    "*.cu",
+]
+
+[platform.one]
+commands = "one.json"
+
+[platform.two]
+commands = "two.json"

--- a/tests/schema/invalid_analysis.toml
+++ b/tests/schema/invalid_analysis.toml
@@ -1,0 +1,11 @@
+[codebase]
+exclude = [
+    1,
+    2,
+]
+
+[platform.one]
+commands = "one.json"
+
+[platform.two]
+commands = "two.json"

--- a/tests/schema/test_schema.py
+++ b/tests/schema/test_schema.py
@@ -55,6 +55,32 @@ class TestSchema(unittest.TestCase):
             with self.assertRaises(ValueError):
                 toml = util._load_toml(f, "cbiconfig")
 
+    def test_analysis_file(self):
+        """schema/analysis_file"""
+
+        path = "./tests/schema/analysis.toml"
+        with open(path, "rb") as f:
+            toml = util._load_toml(f, "analysis")
+            expected = {
+                "codebase": {
+                    "exclude": ["*.F90", "*.cu"],
+                },
+                "platform": {
+                    "one": {
+                        "commands": "one.json",
+                    },
+                    "two": {
+                        "commands": "two.json",
+                    },
+                },
+            }
+            self.assertEqual(toml, expected)
+
+        path = "./tests/schema/invalid_analysis.toml"
+        with open(path, "rb") as f:
+            with self.assertRaises(ValueError):
+                toml = util._load_toml(f, "analysis")
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Using TOML is more straightforward than YAML for our purposes. With TOML, users will be less likely to encounter strange corner cases (e.g., broken indentation, values not being recognized as strings).

Adopting a new way to describe analysis options also gives us an opportunity to clean up and revisit several legacy design decisions, such as:
- Requiring the codebase to be described as a list of files.
- Requiring excludes to be specified as globs.
- Allowing platforms to be defined without a compilation database.
- Expecting to find a CBI configuration file at a generic path ("config.yaml").

With the new approach, specifying the analysis to perform uses a positional argument:
```sh
codebasin analysis.toml
```

...and this can be combined with options like `-x` and `-p` to override options specified in the file.

# Related issues

<!--
If applicable, provide a list of related issues here.

Consider using a keyword like "closes" to automatically link this pull request
to any issues that should be automatically closed when this pull request is
merged. See the GitHub documentation for more information:
https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests

If not applicable, write "N/A".
-->

N/A

# Proposed changes

<!--
List out, with high level descriptions, what the commits within this pull
request do.
-->

- Accept `*.toml` as a positional argument.
- Check that `-c` and `*.toml` cannot be specified at the same time.
- Deprecate old YAML file configuration files.
- Add ability to load codebase excludes and platform commands from the `*.toml` file.
- Add tests to validate new analysis TOML files against a schema.

There are some gymnastics required here to support both the legacy and modern interfaces simultaneously, which I don't like.  But it doesn't seem worthwhile to refactor things (yet), since all of the YAML stuff can be removed as soon as we've released 1.2.0.