### PR TITLE
Add Github action to run `unittest`

### DIFF
--- a/.github/workflows/run-unittest.yml
+++ b/.github/workflows/run-unittest.yml
@@ -1,0 +1,26 @@
+name: CBI unittest
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # currently just one version, but later releases can be
+        # added as they're needed
+        python-version: ["3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install `code-base-investigator`
+        run: |
+          python -m pip install -U pip
+          pip install .
+      - name: Run `unittest`
+        run: |
+          python -m unittest

--- a/.github/workflows/run-unittest.yml
+++ b/.github/workflows/run-unittest.yml
@@ -1,6 +1,24 @@
 name: CBI unittest
 
-on: [push]
+on:
+  push:
+    branches: [ "main" ]
+    paths:
+      - 'bin/**'
+      - 'codebasin/**'
+      - 'etc/**'
+      - 'tests/**'
+      - 'MANIFEST.in'
+      - 'setup.py'
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - 'bin/**'
+      - 'codebasin/**'
+      - 'etc/**'
+      - 'tests/**'
+      - 'MANIFEST.in'
+      - 'setup.py'
 
 jobs:
   build:

--- a/.github/workflows/run-unittest.yml
+++ b/.github/workflows/run-unittest.yml
@@ -1,5 +1,7 @@
 name: CBI unittest
 
+permissions: read-all
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
# Related issues

Partially addresses #47, adding `unittest` as part of checks.

# Proposed changes

- Add a Github action to run `unittest` after installing CBI
- Supports Python version matrix, which can be updated later to add more Python versions to test against

Currently because of #63 one of the tests (`test_cbiconfig_file`) will fail.