### PR TITLE
Separate deprecated options in -h output

### DIFF
--- a/bin/codebasin
+++ b/bin/codebasin
@@ -43,7 +43,8 @@ def main():
     parser = argparse.ArgumentParser(
         description="Code Base Investigator v" + str(version),
     )
-    parser.add_argument(
+    deprecated_args = parser.add_argument_group("deprecated options")
+    deprecated_args.add_argument(
         "-r",
         "--rootdir",
         dest="rootdir",
@@ -60,7 +61,7 @@ def main():
         help="Set path to source directory. "
         + "The default is the current directory.",
     )
-    parser.add_argument(
+    deprecated_args.add_argument(
         "-c",
         "--config",
         dest="config_file",
@@ -94,7 +95,7 @@ def main():
         nargs="+",
         help="desired output reports (default: all)",
     )
-    parser.add_argument(
+    deprecated_args.add_argument(
         "-d",
         "--dump",
         dest="dump",
@@ -102,7 +103,7 @@ def main():
         action="store",
         help="dump out annotated platform/parsing tree to <file.json>",
     )
-    parser.add_argument(
+    deprecated_args.add_argument(
         "--batchmode",
         dest="batchmode",
         action="store_true",


### PR DESCRIPTION
Providing a separate group for deprecated options will make it clear to users which options are deprecated before they try to use them.  After this change, running `codebasin -h` produces the following output:

```
usage: codebasin [-h] [-r DIR] [-S <path>] [-c <config-file>] [-v] [-q] [-R REPORT [REPORT ...]] [-d <file.json>] [--batchmode] [-x <pattern>] [-p <platform>] [<analysis-file>]

Code Base Investigator v1.1.1

positional arguments:
  <analysis-file>       TOML file describing the analysis to be performed,including the codebase and platform descriptions.

options:
  -h, --help            show this help message and exit
  -S <path>, --source-dir <path>
                        Set path to source directory. The default is the current directory.
  -v, --verbose         increase verbosity level
  -q, --quiet           decrease verbosity level
  -R REPORT [REPORT ...], --report REPORT [REPORT ...]
                        desired output reports (default: all)
  -x <pattern>, --exclude <pattern>
                        Exclude files matching this pattern from the code base. May be specified multiple times.
  -p <platform>, --platform <platform>
                        Add the specified platform to the analysis. May be a name or a path to a compilation database. May be specified multiple times. If not specified, all known platforms will be included.

deprecated options:
  -r DIR, --rootdir DIR
                        Set working root directory (default .)
  -c <config-file>, --config <config-file>
                        Configuration YAML file. Defaults to config.yaml
  -d <file.json>, --dump <file.json>
                        dump out annotated platform/parsing tree to <file.json>
  --batchmode           Set batch mode (additional output for bulk operation.)
```

# Related issues

<!--
If applicable, provide a list of related issues here.

Consider using a keyword like "closes" to automatically link this pull request
to any issues that should be automatically closed when this pull request is
merged. See the GitHub documentation for more information:
https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests

If not applicable, write "N/A".
-->

N/A

# Proposed changes

<!--
List out, with high level descriptions, what the commits within this pull
request do.
-->

- Separate supported options from deprecated options in the help string.
