### PR TITLE
Make all deprecation warnings DeprecationWarnings

### DIFF
--- a/bin/codebasin
+++ b/bin/codebasin
@@ -174,6 +174,7 @@ def main():
     elif args.rootdir:
         warnings.warn(
             "--rootdir (-r) is deprecated. Use --source-dir (-S) instead.",
+            DeprecationWarning,
         )
         rootpath = args.rootdir
     rootdir = os.path.realpath(rootpath)
@@ -210,7 +211,10 @@ def main():
         len(additional_platforms) == 0 and args.analysis_file is None
     )
     if config_file is None and config_required:
-        warnings.warn("Implicitly defined configuration files are deprecated.")
+        warnings.warn(
+            "Implicitly defined configuration files are deprecated.",
+            DeprecationWarning,
+        )
         config_file = os.path.join(rootdir, "config.yaml")
         if not os.path.exists(config_file):
             raise RuntimeError(f"Could not find config file {config_file}")
@@ -230,6 +234,7 @@ def main():
         warnings.warn(
             "YAML configuration files are deprecated. "
             + "Use TOML analysis files instead.",
+            DeprecationWarning,
         )
         if not util.ensure_yaml(config_file):
             logging.getLogger("codebasin").error(


### PR DESCRIPTION
# Related issues

<!--
If applicable, provide a list of related issues here.

Consider using a keyword like "closes" to automatically link this pull request
to any issues that should be automatically closed when this pull request is
merged. See the GitHub documentation for more information:
https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests

If not applicable, write "N/A".
-->

N/A

# Proposed changes

<!--
List out, with high level descriptions, what the commits within this pull
request do.
-->

- Add `DeprecationWarning` to deprecation warnings that defaulted to `UserWarning`.

---

@laserkelvin: I'm really sorry about this one.  I keep forgetting what `warnings.warn` defaults to.