### PR TITLE
Deprecate passing more than one value to --report

### DIFF
--- a/bin/codebasin
+++ b/bin/codebasin
@@ -160,6 +160,11 @@ def main():
             "--dump will be removed in a future release.",
             DeprecationWarning,
         )
+    if len(args.reports) > 1:
+        warnings.warn(
+            "Passing more than one value to --report (-R) is deprecated.",
+            DeprecationWarning,
+        )
 
     # Determine the root directory based on the -S and -r flags.
     rootpath = None


### PR DESCRIPTION
We previously decided to remove the ability for `--platform (-p)` to accept multiple values due to the potential for ambiguous command lines. For consistency, `--report (-R)` should not accept multiple values either.

Note that this probably won't affect very many people (if any), because previous releases only support three values ("summary", "clustering" and "all").  Passing `-R summary clustering` is equivalent to `-R all`, and passing `-R summary all` or `-R clustering all` doesn't make any sense.

# Related issues

<!--
If applicable, provide a list of related issues here.

Consider using a keyword like "closes" to automatically link this pull request
to any issues that should be automatically closed when this pull request is
merged. See the GitHub documentation for more information:
https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests

If not applicable, write "N/A".
-->

N/A

# Proposed changes

<!--
List out, with high level descriptions, what the commits within this pull
request do.
-->

- Emit a `DeprecationWarning` if `--report` is passed more than one value (e.g., `codebasin -R clustering summary`).
