### PR TITLE
Remove --source-dir (-S) option

### DIFF
--- a/bin/codebasin
+++ b/bin/codebasin
@@ -52,15 +52,6 @@ def main():
         default=None,
         help="Set working root directory (default .)",
     )
-    parser.add_argument(
-        "-S",
-        "--source-dir",
-        metavar="<path>",
-        dest="source_dir",
-        default=None,
-        help="Set path to source directory. "
-        + "The default is the current directory.",
-    )
     deprecated_args.add_argument(
         "-c",
         "--config",
@@ -167,19 +158,13 @@ def main():
             DeprecationWarning,
         )
 
-    # Determine the root directory based on the -S and -r flags.
+    # Determine the root directory based on the -r flag.
     rootpath = None
-    if args.source_dir and args.rootdir:
-        raise RuntimeError(
-            "Cannot specify both --source-dir (-S) and --rootdir (-r).",
-        )
-    if not args.source_dir and not args.rootdir:
+    if not args.rootdir:
         rootpath = os.getcwd()
-    elif args.source_dir:
-        rootpath = args.source_dir
     elif args.rootdir:
         warnings.warn(
-            "--rootdir (-r) is deprecated. Use --source-dir (-S) instead.",
+            "--rootdir (-r) is deprecated.",
             DeprecationWarning,
         )
         rootpath = args.rootdir


### PR DESCRIPTION
We are contemplating adding support for per-platform source directories in a future release. Adding such functionality would make the `-S` flag harder to understand, as some users may expect to be able to specify `-S` multiple times.

To avoid being stuck supporting `-S` after 1.2.0, remove it for now.

# Related issues

<!--
If applicable, provide a list of related issues here.

Consider using a keyword like "closes" to automatically link this pull request
to any issues that should be automatically closed when this pull request is
merged. See the GitHub documentation for more information:
https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests

If not applicable, write "N/A".
-->

N/A

# Proposed changes

<!--
List out, with high level descriptions, what the commits within this pull
request do.
-->

- Remove `-S` from argument parser.
- Remove all references to `--source-dir` and `-S` .
