### PR TITLE
Fix double percent symbol in report output

### DIFF
--- a/codebasin/report.py
+++ b/codebasin/report.py
@@ -113,7 +113,7 @@ def summary(setmap):
     cd = divergence(setmap)
     unused = (setmap[frozenset()] / total_count) * 100.0
     lines += [f"Code Divergence: {cd:.2f}"]
-    lines += [f"Unused Code (%%): {unused:.2f}"]
+    lines += [f"Unused Code (%): {unused:.2f}"]
     lines += [f"Total SLOC: {total_count}"]
 
     return "\n".join(lines)


### PR DESCRIPTION
"%%" was required to render a "%" before we switched to f-strings.

# Related issues

<!--
If applicable, provide a list of related issues here.

Consider using a keyword like "closes" to automatically link this pull request
to any issues that should be automatically closed when this pull request is
merged. See the GitHub documentation for more information:
https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests

If not applicable, write "N/A".
-->

N/A

# Proposed changes

<!--
List out, with high level descriptions, what the commits within this pull
request do.
-->

- Replace "%%" with "%".
