### PR TITLE
Remove --batchmode option

### DIFF
--- a/bin/codebasin
+++ b/bin/codebasin
@@ -108,13 +108,6 @@ def main():
         action="store",
         help="Dump out annotated platform/parsing tree to <file.json>.",
     )
-    deprecated_args.add_argument(
-        "--batchmode",
-        dest="batchmode",
-        action="store_true",
-        default=False,
-        help="Enable additional output for bulk operation.",
-    )
     parser.add_argument(
         "-x",
         "--exclude",
@@ -155,11 +148,6 @@ def main():
     )
 
     # Warnings for deprecated functionality with no planned replacement.
-    if args.batchmode:
-        warnings.warn(
-            "--batchmode will be removed in a future release.",
-            DeprecationWarning,
-        )
     if args.dump:
         warnings.warn(
             "--dump will be removed in a future release.",
@@ -290,12 +278,6 @@ def main():
         if "all" in args.reports:
             return True
         return name in args.reports
-
-    if args.batchmode and (
-        report_enabled("summary") or report_enabled("clustering")
-    ):
-        print(f"Config file: {config_file}")
-        print(f"Root: {rootdir}")
 
     # Print summary report
     if report_enabled("summary"):


### PR DESCRIPTION
This functionality was deprecated in 1.2.0.

# Related issues

<!--
If applicable, provide a list of related issues here.

Consider using a keyword like "closes" to automatically link this pull request
to any issues that should be automatically closed when this pull request is
merged. See the GitHub documentation for more information:
https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests

If not applicable, write "N/A".
-->

Part of the fix for #87.

# Proposed changes

<!--
List out, with high level descriptions, what the commits within this pull
request do.
-->

- Remove `--batchmode` option from arguments.
- Remove batch mode deprecation warning.
- Remove print statements that were only enabled in batch mode.
