### PR TITLE
Remove --root-dir option

### DIFF
--- a/bin/codebasin
+++ b/bin/codebasin
@@ -58,15 +58,6 @@ def main():
     )
     deprecated_args = parser.add_argument_group("deprecated options")
     deprecated_args.add_argument(
-        "-r",
-        "--rootdir",
-        dest="rootdir",
-        metavar="<dir>",
-        default=None,
-        help="Set working root directory. "
-        + "Defaults to current working directory.",
-    )
-    deprecated_args.add_argument(
         "-c",
         "--config",
         dest="config_file",
@@ -171,17 +162,8 @@ def main():
             DeprecationWarning,
         )
 
-    # Determine the root directory based on the -r flag.
-    rootpath = None
-    if not args.rootdir:
-        rootpath = os.getcwd()
-    elif args.rootdir:
-        warnings.warn(
-            "--rootdir (-r) is deprecated.",
-            DeprecationWarning,
-        )
-        rootpath = args.rootdir
-    rootdir = os.path.realpath(rootpath)
+    # Determine the root directory based on where codebasin is run.
+    rootdir = os.path.realpath(os.getcwd())
 
     if args.config_file and args.analysis_file:
         raise RuntimeError(


### PR DESCRIPTION
This functionality was previously deprecated in 1.2.0.

This commit does not remove the concept of a root directory, which is still used to determine whether a file belongs to the code base.

# Related issues

<!--
If applicable, provide a list of related issues here.

Consider using a keyword like "closes" to automatically link this pull request
to any issues that should be automatically closed when this pull request is
merged. See the GitHub documentation for more information:
https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests

If not applicable, write "N/A".
-->

Part of the fix for #87.

# Proposed changes

<!--
List out, with high level descriptions, what the commits within this pull
request do.
-->

- Remove `--root-dir` option from arguments.
- Remove root directory deprecation warning.
- Set root directory to the current working directory unconditionally.
