### PR TITLE
Remove --dump option

### DIFF
--- a/bin/codebasin
+++ b/bin/codebasin
@@ -93,14 +93,6 @@ def main():
         + "May be specified multiple times. "
         + "If not specified, all reports will be generated.",
     )
-    deprecated_args.add_argument(
-        "-d",
-        "--dump",
-        dest="dump",
-        metavar="<file.json>",
-        action="store",
-        help="Dump out annotated platform/parsing tree to <file.json>.",
-    )
     parser.add_argument(
         "-x",
         "--exclude",
@@ -139,13 +131,6 @@ def main():
     logging.getLogger("codebasin").setLevel(
         max(1, logging.WARNING - 10 * (args.verbose - args.quiet)),
     )
-
-    # Warnings for deprecated functionality with no planned replacement.
-    if args.dump:
-        warnings.warn(
-            "--dump will be removed in a future release.",
-            DeprecationWarning,
-        )
 
     # If no specific report was specified, generate all reports.
     # Handled here to prevent "all" always being in the list.
@@ -248,15 +233,6 @@ def main():
     # Count lines for platforms
     platform_mapper = PlatformMapper(codebase)
     setmap = platform_mapper.walk(state)
-
-    if args.dump:
-        if util.ensure_json(args.dump):
-            report.annotated_dump(args.dump, state)
-        else:
-            logging.getLogger("codebasin").warning(
-                "Output path for annotation dump does not end with .json: "
-                f"'{args.dump}'. Skipping dump.",
-            )
 
     def report_enabled(name):
         if "all" in args.reports:

--- a/codebasin/preprocessor.py
+++ b/codebasin/preprocessor.py
@@ -551,12 +551,6 @@ class Node:
         self.children.append(child)
         child.parent = self
 
-    def to_json(self, assoc):
-        return {
-            "platforms": list(assoc[self]),
-            "children": [x.to_json(assoc) for x in self.children],
-        }
-
     @staticmethod
     def is_start_node():
         """
@@ -614,17 +608,6 @@ class FileNode(Node):
 
         return hasher.hexdigest()
 
-    def to_json(self, assoc):
-        parent_json = super().to_json(assoc)
-        mydict = {
-            "type": "file",
-            "file": self.filename,
-            "name": os.path.basename(self.filename),
-            "sloc": self.total_sloc,
-        }
-        parent_json.update(mydict)
-        return parent_json
-
     def __repr__(self):
         return _representation_string(self, attrs=["filename"])
 
@@ -652,23 +635,6 @@ class CodeNode(Node):
         self.end_line = end_line
         self.num_lines = num_lines
         self.source = source
-
-    def to_json(self, assoc):
-        parent_json = super().to_json(assoc)
-        if self.source:
-            source = "\n".join(self.source)
-        else:
-            source = None
-
-        mydict = {
-            "type": "code",
-            "start_line": self.start_line,
-            "end_line": self.end_line,
-            "sloc": self.num_lines,
-            "source": source,
-        }
-        parent_json.update(mydict)
-        return parent_json
 
     def __repr__(self):
         return _representation_string(
@@ -706,12 +672,6 @@ class DirectiveNode(CodeNode):
 
     def __init__(self):
         super().__init__()
-
-    def to_json(self, assoc):
-        parent_json = super().to_json(assoc)
-        mydict = {"type": "directive", "source": "\n".join(self.spelling())}
-        parent_json.update(mydict)
-        return parent_json
 
 
 class UnrecognizedDirectiveNode(DirectiveNode):

--- a/codebasin/report.py
+++ b/codebasin/report.py
@@ -5,24 +5,12 @@ Contains functions for generating command-line reports.
 """
 
 import itertools as it
-import json
 import logging
 import warnings
 
 from codebasin import util
 
 log = logging.getLogger("codebasin")
-
-
-def annotated_dump(output_file, state):
-    outlist = []
-    for fname in state.get_filenames():
-        source_tree = state.get_tree(fname)
-        node_associations = state.get_map(fname)
-        outlist.append(source_tree.root.to_json(node_associations))
-
-    with open(output_file, "w") as fp:
-        fp.write(json.dumps(outlist, indent=2))
 
 
 def extract_platforms(setmap):


### PR DESCRIPTION
# Related issues

<!--
If applicable, provide a list of related issues here.

Consider using a keyword like "closes" to automatically link this pull request
to any issues that should be automatically closed when this pull request is
merged. See the GitHub documentation for more information:
https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests

If not applicable, write "N/A".
-->

Part of the fix for #87.

# Proposed changes

<!--
List out, with high level descriptions, what the commits within this pull
request do.
-->

- Remove `--dump` parsing and handling.
- Remove the ability to dump an annotated report.
- Remove functionality that was only used by `--dump` and the annotated report.
