### PR TITLE
CI pre-commit alignment

### DIFF
--- a/.github/workflows/run-precommit.yml
+++ b/.github/workflows/run-precommit.yml
@@ -1,8 +1,6 @@
 name: Run pre-commit hooks
 
 on:
-  push:
-    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 

--- a/.github/workflows/run-precommit.yml
+++ b/.github/workflows/run-precommit.yml
@@ -1,0 +1,28 @@
+name: Run pre-commit hooks
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-python@v5
+        name: Install Python 3.12
+        with:
+          python-version: "3.12"
+          cache: 'pip'
+      - run: pip install -U pip setuptools
+      - uses: pre-commit/action@v3.0.1
+        name: Configure and run pre-commit on changed files
+        with:
+          # the intention with this is to run pre-commit only
+          # on the diff submitted with this PR
+          extra_args: --color=always --from-ref ${{ github.event.pull_request.base.sha }} --to-ref ${{ github.event.pull_request.head.sha }}
+permissions: read-all

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,7 +29,7 @@ repos:
     rev: v3.10.1
     hooks:
       - id: pyupgrade
-        args: [--py39-plus]
+        args: [--py39-plus, --py310-plus, --py311-plus]
 
   - repo: https://github.com/psf/black
     rev: 23.7.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,7 @@ repos:
           ]
         args:
           [
-            "--extend-ignore=S105,E203",
+            "--extend-ignore=S105,E203,W503,E701",
             "--per-file-ignores=__init__.py:F401",
           ]
 


### PR DESCRIPTION
# Related issues

This partially addresses #47 by running `pre-commit` as a Github action, ensuring the same tooling is used for both offline development and code review.

# Proposed changes

- Add a pre-commit Github action that runs the pre-commit hooks on the PR diffs
- Updates `.pre-commmit-config.yaml` to be consistent with what was defined for P3
- Adds higher Python version checks to `pyupgrade` in the pre-commit workflow to align with Python 3.12 usage.
