### PR TITLE
`pyproject.toml` migration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,7 +41,6 @@ dependencies = [
 [project.optional-dependencies]
 dev = [
   "sphinx",
-  "sphinx-gallery",
   "pre-commit",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,58 @@
+# Copyright (C) 2024 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+[build-system]
+build-backend = "setuptools.build_meta"
+requires = ["setuptools >= 61.0"]
+
+[project]
+authors = [
+  {"name" = "S. John Pennycook", "email" = "john.pennycook@intel.com"},
+]
+description = "Code Base Investigator"
+version = "1.2.0"
+dynamic = ["readme"]
+keywords = ["performance", "portability", "productivity"]
+name = "codebasin"
+requires-python = ">=3.9"
+classifiers = [
+  "Development Status :: 5 - Production/Stable",
+  "Environment :: Console",
+  "Intended Audience :: Developers",
+  "License :: OSI Approved :: BSD License",
+  "Programming Language :: Python",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python :: 3.12",
+  "Topic :: Software Development",
+]
+dependencies = [
+  "numpy==1.26.0",
+  "matplotlib==3.8.2",
+  "pathspec==0.12.1",
+  "pyyaml==6.0.1",
+  "scipy==1.12.0",
+  "jsonschema==4.21.1",
+]
+
+[project.urls]
+"Github" = "https://www.github.com/intel/code-base-investigator"
+"Issues" = "https://www.github.com/intel/code-base-investigator/issues"
+"Pull requests" = "https://www.github.com/intel/code-base-investigator/pulls"
+
+[project.optional-dependencies]
+dev = [
+  "sphinx",
+  "sphinx-gallery",
+  "pre-commit",
+]
+
+[tool.setuptools]
+# TODO this practice is deprecated and will need updating later
+script-files = ["bin/codebasin"]
+include-package-data = true
+
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["codebasin*"]
+
+[tool.setuptools.dynamic]
+readme = {file = ["README.md"]}

--- a/setup.py
+++ b/setup.py
@@ -1,36 +1,8 @@
 #!/usr/bin/env python3
-# Copyright (C) 2019 Intel Corporation
+# Copyright (C) 2019-24 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
 from setuptools import setup
 
-setup(
-    name="codebasin",
-    version="1.2.0",
-    description="Code Base Investigator",
-    author="John Pennycook",
-    author_email="john.pennycook@intel.com",
-    url="https://www.github.com/intel/code-base-investigator",
-    packages=["codebasin", "codebasin.schema", "codebasin.walkers"],
-    include_package_data=True,
-    scripts=["bin/codebasin"],
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Environment :: Console",
-        "Intended Audience :: Developers",
-        "License :: OSI Approved :: BSD License",
-        "Programming Language :: Python",
-        "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.12",
-        "Topic :: Software Development",
-    ],
-    python_requires=">=3.12",
-    install_requires=[
-        "numpy==1.26.0",
-        "matplotlib==3.8.2",
-        "pathspec==0.12.1",
-        "pyyaml==6.0.1",
-        "scipy==1.12.0",
-        "jsonschema==4.21.1",
-    ],
-)
+if __name__ == "__main__":
+    setup()


### PR DESCRIPTION
# Related issues

Related to #93, which required either a `requirements.txt` or `pyproject.toml` specification for `setup_python` action.

# Proposed changes

- Moves bulk of setup configuration from `setup.py` to `pyproject.toml`
