### PR TITLE
Simplify the --report option

### DIFF
--- a/bin/codebasin
+++ b/bin/codebasin
@@ -90,7 +90,8 @@ def main():
         default=[],
         choices=["all", "summary", "clustering"],
         help="Generate a report of the specified type. "
-        + "May be specified multiple times.",
+        + "May be specified multiple times. "
+        + "If not specified, all reports will be generated.",
     )
     deprecated_args.add_argument(
         "-d",

--- a/bin/codebasin
+++ b/bin/codebasin
@@ -86,10 +86,11 @@ def main():
         "--report",
         dest="reports",
         metavar="<report>",
-        default=["all"],
+        action="append",
+        default=[],
         choices=["all", "summary", "clustering"],
-        nargs="+",
-        help="Generate a report of the specified type.",
+        help="Generate a report of the specified type. "
+        + "May be specified multiple times.",
     )
     deprecated_args.add_argument(
         "-d",
@@ -144,11 +145,11 @@ def main():
             "--dump will be removed in a future release.",
             DeprecationWarning,
         )
-    if len(args.reports) > 1:
-        warnings.warn(
-            "Passing more than one value to --report (-R) is deprecated.",
-            DeprecationWarning,
-        )
+
+    # If no specific report was specified, generate all reports.
+    # Handled here to prevent "all" always being in the list.
+    if len(args.reports) == 0:
+        args.reports = ["all"]
 
     # Determine the root directory based on where codebasin is run.
     rootdir = os.path.realpath(os.getcwd())


### PR DESCRIPTION
This commit brings `--report` in line with `--platform`, such that:
- Each instance of `--report` accepts only a single argument.
- `--report` can be specified multiple times.

This is a breaking change, but `--report` accepting multiple values was deprecated in 1.2.0.

# Related issues

<!--
If applicable, provide a list of related issues here.

Consider using a keyword like "closes" to automatically link this pull request
to any issues that should be automatically closed when this pull request is
merged. See the GitHub documentation for more information:
https://docs.github.com/en/get-started/writing-on-github/working-with-advanced-formatting/using-keywords-in-issues-and-pull-requests

If not applicable, write "N/A".
-->

Part of the fix for #87.

# Proposed changes

- Switch `--report` from expecting a list of args (`nargs="+"`) to a single argument.
- Append all `--report` arguments to a list of report options.
- Default to the equivalent of `--report all` for backwards compatibility.

Note that setting a default of `["all"]` for `argparse` would then cause the list to always contain `"all"`.  Rather than writing a custom action for this, it seemed simpler to handle the default elsewhere and add a comment explaining the reasoning.
