### PR TITLE
Format help strings

### DIFF
--- a/bin/codebasin
+++ b/bin/codebasin
@@ -20,19 +20,20 @@ def main():
     # Read command-line arguments
     parser = argparse.ArgumentParser(
         description="Code Base Investigator " + str(version),
+        formatter_class=argparse.RawTextHelpFormatter,
         add_help=False,
     )
     parser.add_argument(
         "-h",
         "--help",
         action="help",
-        help="Display help message and exit.",
+        help="\nDisplay help message and exit.\n ",
     )
     parser.add_argument(
         "--version",
         action="version",
         version=f"Code Base Investigator {version}",
-        help="Display version information and exit.",
+        help="\nDisplay version information and exit.\n ",
     )
     parser.add_argument(
         "-v",
@@ -40,7 +41,7 @@ def main():
         dest="verbose",
         action="count",
         default=0,
-        help="Increase verbosity level.",
+        help="\nIncrease verbosity level.\n ",
     )
     parser.add_argument(
         "-q",
@@ -48,7 +49,7 @@ def main():
         dest="quiet",
         action="count",
         default=0,
-        help="Decrease verbosity level.",
+        help="\nDecrease verbosity level.\n ",
     )
     parser.add_argument(
         "-R",
@@ -58,9 +59,9 @@ def main():
         action="append",
         default=[],
         choices=["all", "summary", "clustering"],
-        help="Generate a report of the specified type. "
-        + "May be specified multiple times. "
-        + "If not specified, all reports will be generated.",
+        help="Generate a report of the specified type.\n"
+        + "May be specified multiple times.\n"
+        + "If not specified, all reports will be generated.\n ",
     )
     parser.add_argument(
         "-x",
@@ -69,8 +70,8 @@ def main():
         metavar="<pattern>",
         action="append",
         default=[],
-        help="Exclude files matching this pattern from the code base. "
-        + "May be specified multiple times.",
+        help="Exclude files matching this pattern from the code base.\n"
+        + "May be specified multiple times.\n ",
     )
     parser.add_argument(
         "-p",
@@ -79,14 +80,14 @@ def main():
         metavar="<platform>",
         action="append",
         default=[],
-        help="Include the specified platform in the analysis. "
-        + "May be specified multiple times. "
-        + "If not specified, all platforms will be included.",
+        help="Include the specified platform in the analysis.\n"
+        + "May be specified multiple times.\n"
+        + "If not specified, all platforms will be included.\n ",
     )
     parser.add_argument(
         "analysis_file",
         metavar="<analysis-file>",
-        help="TOML file describing the analysis to be performed, "
+        help="\nTOML file describing the analysis to be performed, "
         + "including the codebase and platform descriptions.",
     )
 

--- a/bin/codebasin
+++ b/bin/codebasin
@@ -40,6 +40,10 @@ def _help_string(*lines: str, is_long=False, is_last=False):
     if not is_long:
         result = "\n"
 
+    # argparse.HelpFormatter indents by 24 characters.
+    # We cannot override this directly, but can delete them with backspaces.
+    lines = ["\b" * 20 + x for x in lines]
+
     # The additional space is required for argparse to respect newlines.
     result += "\n".join(lines)
 

--- a/bin/codebasin
+++ b/bin/codebasin
@@ -16,6 +16,39 @@ from codebasin.walkers.platform_mapper import PlatformMapper
 version = "1.2.0"
 
 
+def _help_string(*lines: str, is_long=False, is_last=False):
+    """
+    Parameters
+    ----------
+    *lines: str
+        Each line in the help string.
+
+    is_long: bool
+        A flag indicating whether the option is long enough to generate an
+        initial newline by default.
+
+    is_last: bool
+        A flag indicating whether the option is the last in the list.
+
+    Returns
+    -------
+        An argparse help string formatted as a paragraph.
+    """
+    result = ""
+
+    # A long option like --exclude will force a newline.
+    if not is_long:
+        result = "\n"
+
+    # The additional space is required for argparse to respect newlines.
+    result += "\n".join(lines)
+
+    if not is_last:
+        result += "\n "
+
+    return result
+
+
 def main():
     # Read command-line arguments
     parser = argparse.ArgumentParser(
@@ -27,13 +60,13 @@ def main():
         "-h",
         "--help",
         action="help",
-        help="\nDisplay help message and exit.\n ",
+        help=_help_string("Display help message and exit."),
     )
     parser.add_argument(
         "--version",
         action="version",
         version=f"Code Base Investigator {version}",
-        help="\nDisplay version information and exit.\n ",
+        help=_help_string("Display version information and exit."),
     )
     parser.add_argument(
         "-v",
@@ -41,7 +74,7 @@ def main():
         dest="verbose",
         action="count",
         default=0,
-        help="\nIncrease verbosity level.\n ",
+        help=_help_string("Increase verbosity level."),
     )
     parser.add_argument(
         "-q",
@@ -49,7 +82,7 @@ def main():
         dest="quiet",
         action="count",
         default=0,
-        help="\nDecrease verbosity level.\n ",
+        help=_help_string("Decrease verbosity level."),
     )
     parser.add_argument(
         "-R",
@@ -59,9 +92,12 @@ def main():
         action="append",
         default=[],
         choices=["all", "summary", "clustering"],
-        help="Generate a report of the specified type.\n"
-        + "May be specified multiple times.\n"
-        + "If not specified, all reports will be generated.\n ",
+        help=_help_string(
+            "Generate a report of the specified type.",
+            "May be specified multiple times.",
+            "If not specified, all reports will be generated.",
+            is_long=True,
+        ),
     )
     parser.add_argument(
         "-x",
@@ -70,8 +106,11 @@ def main():
         metavar="<pattern>",
         action="append",
         default=[],
-        help="Exclude files matching this pattern from the code base.\n"
-        + "May be specified multiple times.\n ",
+        help=_help_string(
+            "Exclude files matching this pattern from the code base.",
+            "May be specified multiple times.",
+            is_long=True,
+        ),
     )
     parser.add_argument(
         "-p",
@@ -80,15 +119,23 @@ def main():
         metavar="<platform>",
         action="append",
         default=[],
-        help="Include the specified platform in the analysis.\n"
-        + "May be specified multiple times.\n"
-        + "If not specified, all platforms will be included.\n ",
+        help=_help_string(
+            "Include the specified platform in the analysis.",
+            "May be specified multiple times.",
+            "If not specified, all platforms will be included.",
+            is_long=True,
+            is_last=True,
+        ),
     )
+
     parser.add_argument(
         "analysis_file",
         metavar="<analysis-file>",
-        help="\nTOML file describing the analysis to be performed, "
-        + "including the codebase and platform descriptions.",
+        help=_help_string(
+            "TOML file describing the analysis to be performed, "
+            + "including the codebase and platform descriptions.",
+            is_last=True,
+        ),
     )
 
     args = parser.parse_args()


### PR DESCRIPTION
# Related issues

Closes #45.

# Proposed changes

- Adds `_help_string` function to consistently format help strings.
- Adds `\n` and `\b` characters in the right places to adjust `argparse` formatting.

This might look like a bit of a hack, but all other solutions I could find to this problem rely on creating a subclass of `HelpFormatter` that relies on undocumented behavior.