### PR TITLE
Add coverage configuration to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,3 +55,10 @@ include = ["codebasin*"]
 
 [tool.setuptools.dynamic]
 readme = {file = ["README.md"]}
+
+[tool.coverage.run]
+command_line = "-m unittest"
+source = ["codebasin"]
+
+[tool.coverage.report]
+show_missing = true


### PR DESCRIPTION
Following these changes, running `coverage run` in the root directory produces output like the following:
```
Name                                   Stmts   Miss  Cover   Missing
--------------------------------------------------------------------
codebasin/__init__.py                    112      4    96%   89, 282, 293-294
codebasin/config.py                      209     42    80%   27, 29-30, 53, 66, 68-69, 84-91, 132-135, 210-211, 220, 247-248, 261, 281, 293, 312, 339, 360-378
codebasin/file_parser.py                  98      4    96%   75, 77, 169, 216
codebasin/file_source.py                 438     35    92%   97, 137, 169-170, 176, 180, 225-226, 248-249, 275, 284, 294, 339-340, 381-382, 387-388, 407, 411, 467, 499-500, 525, 529, 568, 604-605, 609, 650-652, 694, 708
codebasin/finder.py                       95     31    67%   26-28, 56-86, 102, 118, 127, 180-191
codebasin/language.py                     21      0   100%
codebasin/platform.py                     48      0   100%
codebasin/preprocessor.py               1199    150    87%   31, 43-48, 81, 107, 118, 127, 166, 175, 184, 193, 311-312, 317, 388-389, 475-477, 516-523, 529, 612, 615, 640, 646-649, 660-663, 688, 695, 709, 716-717, 737, 744-752, 774, 781, 801, 811-813, 816, 831, 838-843, 904, 911-912, 954, 961, 981, 988, 1099, 1409-1410, 1418-1419, 1464, 1466, 1498-1503, 1507, 1523, 1530-1531, 1551, 1572, 1582-1584, 1622-1625, 1630, 1637, 1643-1645, 1648, 1653, 1660-1661, 1796, 1819, 1829, 1838, 1875, 1898-1902, 1904, 1908-1909, 1969, 1983, 2113, 2215, 2246-2247, 2257, 2259, 2262-2265, 2273, 2277, 2279, 2281, 2285, 2289, 2291, 2294-2309, 2334, 2350-2353, 2376
codebasin/report.py                       95     95     0%   7-175
codebasin/source.py                        9      0   100%
codebasin/util.py                         83     28    66%   28-33, 38-42, 47, 52-71, 76, 144, 149-150, 159-161, 191-194, 279-288
codebasin/walkers/__init__.py              0      0   100%
codebasin/walkers/exporter.py             32     32     0%   4-57
codebasin/walkers/platform_mapper.py      18      0   100%
codebasin/walkers/source_printer.py       45     45     0%   4-94
codebasin/walkers/tree_associator.py      20      0   100%
codebasin/walkers/tree_mapper.py          14      0   100%
codebasin/walkers/tree_printer.py         15     15     0%   4-37
codebasin/walkers/tree_walker.py           6      0   100%
--------------------------------------------------------------------
TOTAL                                   2557    481    81%
```

# Related issues

Progress towards #36.

The changes in this PR configure `coverage` correctly, but do not attempt to make it part of the CI pipeline.  I think we need some more discussion about what exactly the CI pipeline should do here (e.g., whether it should just produce a badge, whether it should complain about new lines without tests, etc).

# Proposed changes

- Configure `coverage` to automatically run with `-m unittest` and analyze codebasin/ files.
- Configure coverage report to show a list of missing lines.
