### PR TITLE
Switch to per-module loggers

### DIFF
--- a/codebasin/config.py
+++ b/codebasin/config.py
@@ -12,7 +12,7 @@ import re
 
 from codebasin import CompilationDatabase, util
 
-log = logging.getLogger("codebasin")
+log = logging.getLogger(__name__)
 
 
 def extract_defines(argv):

--- a/codebasin/file_parser.py
+++ b/codebasin/file_parser.py
@@ -11,7 +11,7 @@ import os
 from codebasin import preprocessor, util
 from codebasin.file_source import get_file_source
 
-log = logging.getLogger("codebasin")
+log = logging.getLogger(__name__)
 
 
 class LineGroup:

--- a/codebasin/file_source.py
+++ b/codebasin/file_source.py
@@ -10,7 +10,7 @@ import logging
 
 from codebasin.language import FileLanguage
 
-log = logging.getLogger("codebasin")
+log = logging.getLogger(__name__)
 
 # This string was created by looking at all unicode code points
 # and checking to see if they are considered whitespace

--- a/codebasin/finder.py
+++ b/codebasin/finder.py
@@ -14,7 +14,7 @@ from codebasin import file_parser, platform, preprocessor, util
 from codebasin.language import FileLanguage
 from codebasin.walkers.tree_associator import TreeAssociator
 
-log = logging.getLogger("codebasin")
+log = logging.getLogger(__name__)
 
 
 class FileInfo:

--- a/codebasin/preprocessor.py
+++ b/codebasin/preprocessor.py
@@ -18,7 +18,7 @@ import numpy as np
 from codebasin import util
 from codebasin.walkers.tree_associator import TreeAssociator
 
-log = logging.getLogger("codebasin")
+log = logging.getLogger(__name__)
 
 
 def toklist_print(toklist):

--- a/codebasin/report.py
+++ b/codebasin/report.py
@@ -10,7 +10,7 @@ import warnings
 
 from codebasin import util
 
-log = logging.getLogger("codebasin")
+log = logging.getLogger(__name__)
 
 
 def extract_platforms(setmap):

--- a/codebasin/util.py
+++ b/codebasin/util.py
@@ -20,7 +20,7 @@ from os.path import splitext
 
 import jsonschema
 
-log = logging.getLogger("codebasin")
+log = logging.getLogger(__name__)
 
 
 def compute_file_hash(fname):

--- a/tests/basic_asm/test_basic_asm.py
+++ b/tests/basic_asm/test_basic_asm.py
@@ -16,7 +16,7 @@ class TestBasicAsm(unittest.TestCase):
 
     def setUp(self):
         self.rootdir = Path(__file__).parent.resolve()
-        logging.getLogger("codebasin").disabled = True
+        logging.disable()
 
         self.expected_setmap = {frozenset(["CPU"]): 24}
 

--- a/tests/basic_fortran/test_basic_fortran.py
+++ b/tests/basic_fortran/test_basic_fortran.py
@@ -16,7 +16,7 @@ class TestBasicFortran(unittest.TestCase):
 
     def setUp(self):
         self.rootdir = Path(__file__).parent.resolve()
-        logging.getLogger("codebasin").disabled = True
+        logging.disable()
 
         self.expected_setmap = {
             frozenset(["CPU"]): 2,

--- a/tests/build-dir/test_build_dir.py
+++ b/tests/build-dir/test_build_dir.py
@@ -18,7 +18,7 @@ class TestBuildDirectories(unittest.TestCase):
 
     def setUp(self):
         self.rootdir = Path(__file__).parent.resolve()
-        logging.getLogger("codebasin").disabled = False
+        logging.disable(logging.NOTSET)
 
     def test_absolute_paths(self):
         """

--- a/tests/code-base/test_code_base.py
+++ b/tests/code-base/test_code_base.py
@@ -16,7 +16,7 @@ class TestCodeBase(unittest.TestCase):
     """
 
     def setUp(self):
-        logging.getLogger("codebasin").disabled = False
+        logging.disable()
         warnings.simplefilter("ignore", ResourceWarning)
 
         # Create a temporary codebase spread across two directories

--- a/tests/commented_directive/test_commented_directive.py
+++ b/tests/commented_directive/test_commented_directive.py
@@ -17,7 +17,7 @@ class TestCommentedDirective(unittest.TestCase):
 
     def setUp(self):
         self.rootdir = Path(__file__).parent.resolve()
-        logging.getLogger("codebasin").disabled = True
+        logging.disable()
 
         self.expected_setmap = {frozenset(["CPU", "GPU"]): 5}
 

--- a/tests/compilers/test_compilers.py
+++ b/tests/compilers/test_compilers.py
@@ -12,7 +12,7 @@ class TestCompilers(unittest.TestCase):
     """
 
     def setUp(self):
-        logging.getLogger("codebasin").disabled = True
+        logging.disable()
 
     def test_clang(self):
         """compilers/clang"""

--- a/tests/define/test_define.py
+++ b/tests/define/test_define.py
@@ -16,7 +16,7 @@ class TestDefine(unittest.TestCase):
 
     def setUp(self):
         self.rootdir = Path(__file__).parent.resolve()
-        logging.getLogger("codebasin").disabled = True
+        logging.disable()
 
         self.expected_setmap = {
             frozenset([]): 4,

--- a/tests/disjoint/test_disjoint.py
+++ b/tests/disjoint/test_disjoint.py
@@ -18,7 +18,7 @@ class TestDisjointCodebase(unittest.TestCase):
 
     def setUp(self):
         self.rootdir = Path(__file__).parent.resolve()
-        logging.getLogger("codebasin").disabled = True
+        logging.disable()
 
         self.expected_setmap = {frozenset(["CPU"]): 6, frozenset(["GPU"]): 6}
 

--- a/tests/duplicates/test_duplicates.py
+++ b/tests/duplicates/test_duplicates.py
@@ -16,7 +16,7 @@ class TestDuplicates(unittest.TestCase):
 
     def setUp(self):
         self.rootdir = Path(__file__).parent.resolve()
-        logging.getLogger("codebasin").disabled = True
+        logging.disable()
 
     def test_duplicates(self):
         """Check that duplicate files count towards divergence."""

--- a/tests/exclude/test_exclude.py
+++ b/tests/exclude/test_exclude.py
@@ -16,7 +16,7 @@ class TestExclude(unittest.TestCase):
 
     def setUp(self):
         self.rootdir = Path(__file__).parent.resolve()
-        logging.getLogger("codebasin").disabled = True
+        logging.disable()
 
     def _get_setmap(self, excludes):
         codebase = CodeBase(

--- a/tests/include/test_include.py
+++ b/tests/include/test_include.py
@@ -17,7 +17,7 @@ class TestInclude(unittest.TestCase):
 
     def setUp(self):
         self.rootdir = Path(__file__).parent.resolve()
-        logging.getLogger("codebasin").disabled = True
+        logging.disable()
 
         self.expected_setmap = {
             frozenset(["CPU"]): 11,

--- a/tests/literals/test_literals.py
+++ b/tests/literals/test_literals.py
@@ -17,7 +17,7 @@ class TestLiterals(unittest.TestCase):
 
     def setUp(self):
         self.rootdir = Path(__file__).parent.resolve()
-        logging.getLogger("codebasin").disabled = True
+        logging.disable()
 
         self.expected_setmap = {frozenset(["CPU", "GPU"]): 9}
 

--- a/tests/macro_expansion/test_macro_expansion.py
+++ b/tests/macro_expansion/test_macro_expansion.py
@@ -16,7 +16,7 @@ class TestMacroExpansion(unittest.TestCase):
 
     def setUp(self):
         self.rootdir = Path(__file__).parent.resolve()
-        logging.getLogger("codebasin").disabled = True
+        logging.disable()
 
         self.expected_setmap = {
             frozenset([]): 14,

--- a/tests/multi_line/test_multi_line.py
+++ b/tests/multi_line/test_multi_line.py
@@ -16,7 +16,7 @@ class TestMultiLine(unittest.TestCase):
 
     def setUp(self):
         self.rootdir = Path(__file__).parent.resolve()
-        logging.getLogger("codebasin").disabled = True
+        logging.disable()
 
         self.expected_setmap = {
             frozenset([]): 4,

--- a/tests/nesting/test_nesting.py
+++ b/tests/nesting/test_nesting.py
@@ -16,7 +16,7 @@ class TestNesting(unittest.TestCase):
 
     def setUp(self):
         self.rootdir = Path(__file__).parent.resolve()
-        logging.getLogger("codebasin").disabled = True
+        logging.disable()
 
         self.expected_setmap = {
             frozenset(["CPU"]): 6,

--- a/tests/once/test_once.py
+++ b/tests/once/test_once.py
@@ -16,7 +16,7 @@ class TestOnce(unittest.TestCase):
 
     def setUp(self):
         self.rootdir = Path(__file__).parent.resolve()
-        logging.getLogger("codebasin").disabled = True
+        logging.disable()
 
         self.expected_setmap = {
             frozenset([]): 4,

--- a/tests/operators/test_operators.py
+++ b/tests/operators/test_operators.py
@@ -17,7 +17,7 @@ class TestOperators(unittest.TestCase):
 
     def setUp(self):
         self.rootdir = Path(__file__).parent.resolve()
-        logging.getLogger("codebasin").disabled = True
+        logging.disable()
 
         self.expected_setmap = {frozenset(["CPU", "GPU"]): 32}
 

--- a/tests/schema/test_schema.py
+++ b/tests/schema/test_schema.py
@@ -14,7 +14,7 @@ class TestSchema(unittest.TestCase):
     """
 
     def setUp(self):
-        logging.getLogger("codebasin").disabled = True
+        logging.disable()
 
     def test_compilation_database(self):
         """schema/compilation_database"""


### PR DESCRIPTION
# Related issues

Pre-work for #108.

Switching to per-module loggers (which are best practice anyway) will allow us to separate preprocessor-related messages.

# Proposed changes

- Use `__name__` to give each module its own logger.
- Fix incorrect usage of the `disabled` property of each logger.  Setting `disabled` directly is not allowed (see [here](https://docs.python.org/3/library/logging.html#logging.Logger.disabled)) and doesn't propagate to child loggers.
