### PR TITLE
Force run pre-commit

### DIFF
--- a/codebasin/source.py
+++ b/codebasin/source.py
@@ -3,10 +3,9 @@
 
 import os
 from pathlib import Path
-from typing import Union
 
 
-def is_source_file(filename: Union[str, os.PathLike]) -> bool:
+def is_source_file(filename: str | os.PathLike) -> bool:
     """
     Parameters
     ----------

--- a/tests/comments/test_comments.py
+++ b/tests/comments/test_comments.py
@@ -1,10 +1,10 @@
 # Copyright (C) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
-import unittest
-import logging
 import os
-from codebasin import preprocessor, file_parser
+import unittest
+
+from codebasin import file_parser
 
 
 class TestExampleFortranFile(unittest.TestCase):
@@ -27,11 +27,13 @@ class TestExampleCFile(unittest.TestCase):
 
     def test_c_comments(self):
         rootdir = "./tests/comments/"
-        parser = file_parser.FileParser(os.path.join(rootdir, "continuation.cpp"))
+        parser = file_parser.FileParser(
+            os.path.join(rootdir, "continuation.cpp"),
+        )
 
         tree = parser.parse_file()
         self.assertEqual(tree.root.total_sloc, 25)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/compilers/test_compilers.py
+++ b/tests/compilers/test_compilers.py
@@ -1,9 +1,11 @@
 # Copyright (C) 2019-2024 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
-import unittest
 import logging
+import unittest
+
 from codebasin import config
+
 
 class TestCompilers(unittest.TestCase):
     """
@@ -16,17 +18,13 @@ class TestCompilers(unittest.TestCase):
 
     def test_clang(self):
         """compilers/clang"""
-        args = [
-            "clang",
-            "-fsycl-is-device",
-            "test.cpp"
-        ]
+        args = ["clang", "-fsycl-is-device", "test.cpp"]
 
         compiler = config.recognize_compiler(args)
         self.assertTrue(type(compiler) is config.ClangCompiler)
 
         passes = compiler.get_passes()
-        self.assertEqual(passes, set(["default"]))
+        self.assertEqual(passes, {"default"})
 
         self.assertTrue(compiler.has_implicit_behavior("default"))
         defines = compiler.get_defines("default")
@@ -34,23 +32,15 @@ class TestCompilers(unittest.TestCase):
 
     def test_intel_sycl(self):
         """compilers/intel_sycl"""
-        args = [
-            "icpx",
-            "-fsycl",
-            "test.cpp"
-        ]
+        args = ["icpx", "-fsycl", "test.cpp"]
 
         compiler = config.recognize_compiler(args)
         self.assertTrue(type(compiler) is config.IntelCompiler)
 
         passes = compiler.get_passes()
-        self.assertEqual(passes, set(["default", "spir64"]))
+        self.assertEqual(passes, {"default", "spir64"})
 
-        expected = [
-            "__SYCL_DEVICE_ONLY__",
-            "__SPIR__",
-            "__SPIRV__"
-        ]
+        expected = ["__SYCL_DEVICE_ONLY__", "__SPIR__", "__SPIRV__"]
         self.assertTrue(compiler.has_implicit_behavior("spir64"))
         defines = compiler.get_defines("spir64")
         self.assertEqual(defines, expected)
@@ -62,24 +52,20 @@ class TestCompilers(unittest.TestCase):
             "-fsycl",
             "-fsycl-targets=spir64,x86_64",
             "-fopenmp",
-            "test.cpp"
+            "test.cpp",
         ]
 
         compiler = config.recognize_compiler(args)
         self.assertTrue(type(compiler) is config.IntelCompiler)
 
         passes = compiler.get_passes()
-        self.assertEqual(passes, set(["default", "spir64", "x86_64"]))
+        self.assertEqual(passes, {"default", "spir64", "x86_64"})
 
         self.assertTrue(compiler.has_implicit_behavior("default"))
         defines = compiler.get_defines("default")
         self.assertEqual(defines, ["_OPENMP"])
 
-        expected = [
-            "__SYCL_DEVICE_ONLY__",
-            "__SPIR__",
-            "__SPIRV__"
-        ]
+        expected = ["__SYCL_DEVICE_ONLY__", "__SPIR__", "__SPIRV__"]
         self.assertTrue(compiler.has_implicit_behavior("spir64"))
         defines = compiler.get_defines("spir64")
         self.assertEqual(defines, expected)
@@ -93,19 +79,16 @@ class TestCompilers(unittest.TestCase):
             "nvcc",
             "--gpu-architecture=compute_50",
             "--gpu-code=compute_50,sm_50,sm_52",
-            "test.cpp"
+            "test.cpp",
         ]
 
         compiler = config.recognize_compiler(args)
         self.assertTrue(type(compiler) is config.NvccCompiler)
 
         passes = compiler.get_passes()
-        self.assertEqual(passes, set(["default", "50", "52"]))
+        self.assertEqual(passes, {"default", "50", "52"})
 
-        defaults = [
-            "__NVCC__",
-            "__CUDACC__"
-        ]
+        defaults = ["__NVCC__", "__CUDACC__"]
         self.assertTrue(compiler.has_implicit_behavior("default"))
         defines = compiler.get_defines("default")
         self.assertEqual(defines, defaults)
@@ -118,5 +101,6 @@ class TestCompilers(unittest.TestCase):
         defines = compiler.get_defines("52")
         self.assertEqual(defines, defaults + ["__CUDA_ARCH__=520"])
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     unittest.main()

--- a/tests/failure/test_bignum.py
+++ b/tests/failure/test_bignum.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import unittest
+
 from codebasin import preprocessor
 
 
@@ -13,13 +14,17 @@ class TestBigNum(unittest.TestCase):
     def test_oversized_constant(self):
         """oversized constant"""
         with self.assertRaises(OverflowError):
-            tokens = preprocessor.Lexer("10000000000000000000000000000000000000").tokenize()
+            tokens = preprocessor.Lexer(
+                "10000000000000000000000000000000000000",
+            ).tokenize()
             preprocessor.ExpressionEvaluator(tokens).evaluate()
 
     def test_overflow(self):
         """integer overflow"""
         with self.assertRaises(OverflowError):
-            tokens = preprocessor.Lexer("0xFFFFFFFFFFFFFFFF * 0xFFFFFFFFFFFFFFFF").tokenize()
+            tokens = preprocessor.Lexer(
+                "0xFFFFFFFFFFFFFFFF * 0xFFFFFFFFFFFFFFFF",
+            ).tokenize()
             preprocessor.ExpressionEvaluator(tokens).evaluate()
 
     def test_power(self):

--- a/tests/lexer/test_lexer.py
+++ b/tests/lexer/test_lexer.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import unittest
+
 from codebasin import preprocessor
 
 
@@ -18,15 +19,25 @@ class TestLexer(unittest.TestCase):
 
     def test_numerical(self):
         """numbers"""
-        numbers = ["123", "123ul", "123.4", "123.4e+05", ".123", "0xFF", "0b10"]
+        numbers = [
+            "123",
+            "123ul",
+            "123.4",
+            "123.4e+05",
+            ".123",
+            "0xFF",
+            "0b10",
+        ]
         for number in numbers:
             tokens = preprocessor.Lexer(number).tokenize()
             self.assertTrue(len(tokens) == 1)
-            self.assertTrue(isinstance(tokens[0], preprocessor.NumericalConstant))
+            self.assertTrue(
+                isinstance(tokens[0], preprocessor.NumericalConstant),
+            )
 
     def test_string(self):
         """strings"""
-        tokens = preprocessor.Lexer("\"this is a string constant\"").tokenize()
+        tokens = preprocessor.Lexer('"this is a string constant"').tokenize()
         self.assertTrue(len(tokens) == 1)
         self.assertTrue(isinstance(tokens[0], preprocessor.StringConstant))
 
@@ -34,12 +45,30 @@ class TestLexer(unittest.TestCase):
         """identifiers"""
         tokens = preprocessor.Lexer("this is a string of words").tokenize()
         self.assertTrue(len(tokens) == 6)
-        self.assertTrue(all([isinstance(t, preprocessor.Identifier) for t in tokens]))
+        self.assertTrue(
+            all([isinstance(t, preprocessor.Identifier) for t in tokens]),
+        )
 
     def test_operator(self):
         """operators"""
-        operators = ["||", "&&", ">>", "<<", "!=", ">=", "<=", "==", "##"] + \
-            ["-", "+", "!", "*", "/", "|", "&", "^", "<", ">", "?", ":", "~", "#", "=", "%"]
+        operators = ["||", "&&", ">>", "<<", "!=", ">=", "<=", "==", "##"] + [
+            "-",
+            "+",
+            "!",
+            "*",
+            "/",
+            "|",
+            "&",
+            "^",
+            "<",
+            ">",
+            "?",
+            ":",
+            "~",
+            "#",
+            "=",
+            "%",
+        ]
         for op in operators:
             tokens = preprocessor.Lexer(op).tokenize()
             self.assertTrue(len(tokens) == 1)
@@ -48,7 +77,20 @@ class TestLexer(unittest.TestCase):
 
     def test_puncuator(self):
         """punctuators"""
-        punctuators = ["(", ")", "{", "}", "[", "]", ",", ".", ";", "'", "\"", "\\"]
+        punctuators = [
+            "(",
+            ")",
+            "{",
+            "}",
+            "[",
+            "]",
+            ",",
+            ".",
+            ";",
+            "'",
+            '"',
+            "\\",
+        ]
         for punc in punctuators:
             tokens = preprocessor.Lexer(punc).tokenize()
             self.assertTrue(len(tokens) == 1)
@@ -70,7 +112,9 @@ class TestLexer(unittest.TestCase):
         self.assertTrue(isinstance(tokens[8], preprocessor.Operator))
         self.assertTrue(isinstance(tokens[9], preprocessor.CharacterConstant))
 
-        tokens = preprocessor.Lexer("a > b ? \"true_string\" : \"false_string\"").tokenize()
+        tokens = preprocessor.Lexer(
+            'a > b ? "true_string" : "false_string"',
+        ).tokenize()
         self.assertTrue(len(tokens) == 7)
         self.assertTrue(isinstance(tokens[0], preprocessor.Identifier))
         self.assertTrue(isinstance(tokens[1], preprocessor.Operator))
@@ -81,5 +125,5 @@ class TestLexer(unittest.TestCase):
         self.assertTrue(isinstance(tokens[6], preprocessor.StringConstant))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/parsers/test_directive_parser.py
+++ b/tests/parsers/test_directive_parser.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import unittest
+
 from codebasin import preprocessor
 
 
@@ -68,13 +69,17 @@ class TestDirectiveParser(unittest.TestCase):
 
     def test_include(self):
         """include"""
-        tokens = preprocessor.Lexer("#include <path/to/system/header>").tokenize()
+        tokens = preprocessor.Lexer(
+            "#include <path/to/system/header>",
+        ).tokenize()
         node = preprocessor.DirectiveParser(tokens).parse()
         self.assertTrue(isinstance(node, preprocessor.IncludeNode))
         self.assertTrue(isinstance(node.value, preprocessor.IncludePath))
         self.assertTrue(node.value.system)
 
-        tokens = preprocessor.Lexer("#include \"path/to/local/header\"").tokenize()
+        tokens = preprocessor.Lexer(
+            '#include "path/to/local/header"',
+        ).tokenize()
         node = preprocessor.DirectiveParser(tokens).parse()
         self.assertTrue(isinstance(node, preprocessor.IncludeNode))
         self.assertTrue(isinstance(node.value, preprocessor.IncludePath))
@@ -143,8 +148,10 @@ class TestDirectiveParser(unittest.TestCase):
         for directive in ["#line", "#warning", "#error"]:
             tokens = preprocessor.Lexer(directive).tokenize()
             node = preprocessor.DirectiveParser(tokens).parse()
-            self.assertTrue(isinstance(node, preprocessor.UnrecognizedDirectiveNode))
+            self.assertTrue(
+                isinstance(node, preprocessor.UnrecognizedDirectiveNode),
+            )
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/safe_write/test_safe_write.py
+++ b/tests/safe_write/test_safe_write.py
@@ -1,10 +1,10 @@
 # Copyright (C) 2019 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 
-import unittest
-import tempfile
-import shutil
 import os
+import shutil
+import tempfile
+import unittest
 
 from codebasin import util
 
@@ -76,5 +76,5 @@ class TestSafeWrite(unittest.TestCase):
             self.assertEqual(st.st_mode & 0o111, 0)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/tests/valid_path/test_valid_path.py
+++ b/tests/valid_path/test_valid_path.py
@@ -29,5 +29,5 @@ class TestValidPath(unittest.TestCase):
         self.assertFalse(util.valid_path("/invalid/\n/path/"))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
A small number of source files and tests somehow escaped formatting to the new code style. By forcing pre-commit to run on these files now, we can isolate required formatting changes from new features.

# Related issues

Should fix the pre-commit issues blocking #109.

# Proposed changes

- Apply changes from pre-commit when run on all files in the codebasin/ and tests/ directories.