### PR TITLE
Move code from bin/codebasin to __main__.py

### DIFF
--- a/.github/workflows/run-unittest.yml
+++ b/.github/workflows/run-unittest.yml
@@ -6,7 +6,6 @@ on:
   push:
     branches: [ "main" ]
     paths:
-      - 'bin/**'
       - 'codebasin/**'
       - 'etc/**'
       - 'tests/**'
@@ -15,7 +14,6 @@ on:
   pull_request:
     branches: [ "main" ]
     paths:
-      - 'bin/**'
       - 'codebasin/**'
       - 'etc/**'
       - 'tests/**'

--- a/codebasin/__main__.py
+++ b/codebasin/__main__.py
@@ -240,6 +240,7 @@ def main():
 
 if __name__ == "__main__":
     try:
+        sys.argv[0] = "codebasin"
         main()
     except Exception as e:
         logging.getLogger("codebasin").error(str(e))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,9 @@ dependencies = [
   "jsonschema==4.21.1",
 ]
 
+[project.scripts]
+codebasin = "codebasin:__main__.main"
+
 [project.urls]
 "Github" = "https://www.github.com/intel/code-base-investigator"
 "Issues" = "https://www.github.com/intel/code-base-investigator/issues"
@@ -45,8 +48,6 @@ dev = [
 ]
 
 [tool.setuptools]
-# TODO this practice is deprecated and will need updating later
-script-files = ["bin/codebasin"]
 include-package-data = true
 
 [tool.setuptools.packages.find]


### PR DESCRIPTION
This simple change provides several improvements:

- The codebasin script can be generated by pyproject.toml.
- codebasin can now be invoked as python -m codebasin.
- Editable installs now reflect changes to the command-line interface.

Moving the command-line code into the codebasin/ package should also make it easier to test command-line functionality with unit tests, but this commit does not make any such changes.

# Related issues

N/A

# Proposed changes

- Move bin/codebasin to codebasin/__main__.py.
- Configure pyproject.toml to generate and install a codebasin script.
