### PR TITLE
Improve warning message for missing includes

### DIFF
--- a/codebasin/preprocessor.py
+++ b/codebasin/preprocessor.py
@@ -897,7 +897,12 @@ class IncludeNode(DirectiveNode):
         if not include_file:
             filename = kwargs["filename"]
             line = self.start_line
-            log.warning(f"{filename}:{line}: '{include_path}' not found")
+            spelling = self.spelling()[0]
+            kind = "system include" if is_system_include else "user include"
+            log.warning(
+                f"{filename}:{line}: {kind} '{include_path}' not found\n"
+                + f"{line:>5} | {spelling}",
+            )
 
 
 class IfNode(DirectiveNode):


### PR DESCRIPTION
# Related issues

Closes #50.

I adopted a slightly different solution than that outlined in #50, after offline discussion with @laserkelvin.  Rather than print a large number of suggested actions as part of each individual warning message, we can use a meta-warning to describe suggested fixes just once.

# Proposed changes

- Clarify that the warning pertains to a missing include.
- Differentiate between user and system includes.
- Show the line of code that triggered the warning.

---

A quick example of what this looks like:

```
[WARNING ] /path/to/source/file.cpp:77: user include 'float.h' not found
   77 | #include "float.h"
[WARNING ] /path/to/source/file.cpp:79: system include 'cstring' not found
   79 | #include <cstring>
```

Writing "user" or "system" in the message is mainly there to help us build a `WarningAggregator` that can give different advice in both cases, but it should also be helpful for anybody `grep`ing through the logs.
