### PR TITLE
Remove functionality to merge duplicates

### DIFF
--- a/codebasin/finder.py
+++ b/codebasin/finder.py
@@ -10,22 +10,11 @@ import logging
 import os
 from pathlib import Path
 
-from codebasin import file_parser, platform, preprocessor, util
+from codebasin import file_parser, platform, preprocessor
 from codebasin.language import FileLanguage
 from codebasin.walkers.tree_associator import TreeAssociator
 
 log = logging.getLogger(__name__)
-
-
-class FileInfo:
-    """
-    Data class storing (path, size, sha) for a file.
-    """
-
-    def __init__(self, path, size=None, sha=None):
-        self.path = path
-        self.size = size
-        self.sha = sha
 
 
 class ParserState:
@@ -41,56 +30,12 @@ class ParserState:
         self.maps = {}
         self.langs = {}
         self.summarize_only = summarize_only
-        self.fileinfo = collections.defaultdict(list)
-        self.merge_duplicates = False
-
-    def _map_filename(self, fn):
-        """
-        Map the real filename to an internal filename used by the parser.
-        Enables duplicate files to be merged.
-        """
-        if not self.merge_duplicates:
-            return fn
-
-        # The first time we encounter a filename, store limited info
-        bn = os.path.basename(fn)
-        if bn not in self.fileinfo:
-            self.fileinfo[bn] = [FileInfo(fn)]
-            return fn
-
-        # If filename has been encountered, check for matching size/hash
-        size = os.path.getsize(fn)
-        sha = None
-        for fi in self.fileinfo[bn]:
-            # Fill in missing size information
-            if fi.size is None:
-                fi.size = os.path.getsize(fi.path)
-
-            # If sizes don't match, the file is different
-            if fi.size != size:
-                continue
-
-            # Fill in missing hash information
-            if sha is None:
-                sha = util.compute_file_hash(fn)
-            if fi.sha is None:
-                fi.sha = util.compute_file_hash(fi.path)
-
-            # Use hash to determine if file is duplicate or not
-            if fi.sha != sha:
-                continue
-            return fi.path
-
-        # If no match, this is the first time encountering this file
-        self.fileinfo[bn].append(FileInfo(fn, size, sha))
-        return fn
 
     def insert_file(self, fn, language=None):
         """
         Build a new tree for a source file, and create an association
         map for it.
         """
-        fn = self._map_filename(fn)
         if fn not in self.trees:
             parser = file_parser.FileParser(fn)
             self.trees[fn] = parser.parse_file(
@@ -113,7 +58,6 @@ class ParserState:
         """
         Return the SourceTree associated with a filename
         """
-        fn = self._map_filename(fn)
         if fn not in self.trees:
             return None
         return self.trees[fn]
@@ -122,7 +66,6 @@ class ParserState:
         """
         Return the NodeAssociationMap associated with a filename
         """
-        fn = self._map_filename(fn)
         if fn not in self.maps:
             return None
         return self.maps[fn]

--- a/codebasin/util.py
+++ b/codebasin/util.py
@@ -7,7 +7,6 @@ Contains utility functions for common operations, including:
 - Checking paths
 """
 
-import hashlib
 import json
 import logging
 import os
@@ -21,16 +20,6 @@ from os.path import splitext
 import jsonschema
 
 log = logging.getLogger(__name__)
-
-
-def compute_file_hash(fname):
-    """Return sha512 for fname"""
-    chunk_size = 4096
-    hasher = hashlib.sha512()
-    with safe_open_read_nofollow(fname, "rb") as in_file:
-        for chunk in iter(lambda: in_file.read(chunk_size), b""):
-            hasher.update(chunk)
-    return hasher.hexdigest()
 
 
 def ensure_ext(fname, extensions):


### PR DESCRIPTION
We previously disabled this functionally by setting `merge_duplicates=False`, but stopped short of removing the code.

# Related issues

Arguably part of #36 -- all the code removed by this PR was previously unreachable and untested.

# Proposed changes

- Remove `merge_duplicates` because it's always `False`.
- Remove `_map_filename()` because it does nothing when `merge_duplicates=False`.
- Remove `FileInfo` and `compute_file_hash` because they were only used by `_map_filename`.
