### PR TITLE
Add progress bars to finder.find()

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ portability and maintainability of an application's source code.
 - Python 3
 - PyYAML
 - SciPy
+- tqdm
 
 
 ## Installation

--- a/codebasin/__main__.py
+++ b/codebasin/__main__.py
@@ -321,6 +321,7 @@ def main():
         codebase,
         configuration,
         legacy_warnings=False,
+        show_progress=True,
     )
 
     # Generate meta-warnings and statistics.

--- a/codebasin/finder.py
+++ b/codebasin/finder.py
@@ -9,6 +9,7 @@ import collections
 import logging
 import os
 from pathlib import Path
+
 from tqdm import tqdm
 
 from codebasin import file_parser, platform, preprocessor

--- a/codebasin/finder.py
+++ b/codebasin/finder.py
@@ -107,7 +107,7 @@ def find(
     for f in tqdm(
         filenames,
         desc="Parsing",
-        unit="file",
+        unit=" file",
         leave=False,
         disable=not show_progress,
     ):
@@ -117,14 +117,14 @@ def find(
     for p in tqdm(
         configuration,
         desc="Preprocessing",
-        unit="platform",
+        unit=" platform",
         leave=False,
         disable=not show_progress,
     ):
         for e in tqdm(
             configuration[p],
             desc=p,
-            unit="file",
+            unit=" file",
             leave=False,
             disable=not show_progress,
         ):

--- a/codebasin/finder.py
+++ b/codebasin/finder.py
@@ -9,6 +9,7 @@ import collections
 import logging
 import os
 from pathlib import Path
+from tqdm import tqdm
 
 from codebasin import file_parser, platform, preprocessor
 from codebasin.language import FileLanguage
@@ -78,6 +79,7 @@ def find(
     *,
     summarize_only=True,
     legacy_warnings=True,
+    show_progress=False,
 ):
     """
     Find codepaths in the files provided and return a mapping of source
@@ -91,8 +93,7 @@ def find(
 
     # Build a tree for each unique file for all platforms.
     state = ParserState(summarize_only)
-    for f in codebase:
-        state.insert_file(f)
+    filenames = set(codebase)
     for p in configuration:
         for e in configuration[p]:
             if e["file"] not in codebase:
@@ -102,11 +103,31 @@ def find(
                         f"{filename} found in definition of platform {p} "
                         + "but missing from codebase",
                     )
-            state.insert_file(e["file"])
+            filenames.add(e["file"])
+    for f in tqdm(
+        filenames,
+        desc="Parsing",
+        unit="file",
+        leave=False,
+        disable=not show_progress,
+    ):
+        state.insert_file(f)
 
     # Process each tree, by associating nodes with platforms
-    for p in configuration:
-        for e in configuration[p]:
+    for p in tqdm(
+        configuration,
+        desc="Preprocessing",
+        unit="platform",
+        leave=False,
+        disable=not show_progress,
+    ):
+        for e in tqdm(
+            configuration[p],
+            desc=p,
+            unit="file",
+            leave=False,
+            disable=not show_progress,
+        ):
             file_platform = platform.Platform(p, rootdir)
 
             for path in e["include_paths"]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
   "pyyaml==6.0.1",
   "scipy==1.12.0",
   "jsonschema==4.21.1",
+  "tqdm==4.66.5",
 ]
 
 [project.scripts]


### PR DESCRIPTION
Parsing each file in the codebase and subsequent preprocessing are the two most time-consuming steps of running codebasin.

Adding progress bars for these steps is expected to be a significant improvement to user experience, as it enables a user to reason about how fast codebasin is running and when it may complete.

# Related issues

N/A

# Proposed changes

- Use `tqdm` to implement a progress bar for parsing all source files. The codebase and platform configuration loops are collapsed because we only parse source files once (even if they are used by multiple platforms).
- Use `tqdm` to implement nested progress bars for preprocessing: the outer bar tracks preprocessing for each platform, and the inner bar tracks preprocessing for each source file used by that platform.
- Add a `show_progress` option that defaults to `False`, since other tools (e.g., `cbicov`?) may wish to run the preprocessor without showing the progress bars.
