### PR TITLE
Add visit() function to source tree

### DIFF
--- a/codebasin/preprocessor.py
+++ b/codebasin/preprocessor.py
@@ -541,8 +541,8 @@ class ParseError(ValueError):
 
 
 class Visit(Enum):
-    NEXT = (0,)
-    NEXT_SIBLING = (1,)
+    NEXT = 0
+    NEXT_SIBLING = 1
 
 
 class Node:

--- a/tests/source-tree/test_source_tree.py
+++ b/tests/source-tree/test_source_tree.py
@@ -7,7 +7,7 @@ import unittest
 import warnings
 
 from codebasin.file_parser import FileParser
-from codebasin.preprocessor import CodeNode, DirectiveNode, FileNode
+from codebasin.preprocessor import CodeNode, DirectiveNode, FileNode, Visit
 
 
 class TestSourceTree(unittest.TestCase):
@@ -18,9 +18,6 @@ class TestSourceTree(unittest.TestCase):
     def setUp(self):
         logging.getLogger("codebasin").disabled = False
         warnings.simplefilter("ignore", ResourceWarning)
-
-    def test_walk(self):
-        """Check that walk() visits nodes in the expected order"""
 
         # TODO: Revisit this when SourceTree can be built without a file.
         with tempfile.NamedTemporaryFile(
@@ -43,36 +40,94 @@ class TestSourceTree(unittest.TestCase):
             f.close()
 
             # TODO: Revisit this when __str__() is more reliable.
-            tree = FileParser(f.name).parse_file(summarize_only=False)
-            expected_types = [
-                FileNode,
-                DirectiveNode,
-                CodeNode,
-                DirectiveNode,
-                CodeNode,
-                DirectiveNode,
-                CodeNode,
-                DirectiveNode,
-                CodeNode,
-            ]
-            expected_contents = [
-                f.name,
-                "FOO",
-                "foo",
-                "BAR",
-                "bar",
-                "else",
-                "baz",
-                "endif",
-                "qux",
-            ]
-            for i, node in enumerate(tree.walk()):
-                self.assertTrue(isinstance(node, expected_types[i]))
-                if isinstance(node, CodeNode):
-                    contents = node.spelling()[0]
-                else:
-                    contents = str(node)
-                self.assertTrue(expected_contents[i] in contents)
+            self.tree = FileParser(f.name).parse_file(summarize_only=False)
+            self.filename = f.name
+
+    def test_walk(self):
+        """Check that walk() visits nodes in the expected order"""
+        expected_types = [
+            FileNode,
+            DirectiveNode,
+            CodeNode,
+            DirectiveNode,
+            CodeNode,
+            DirectiveNode,
+            CodeNode,
+            DirectiveNode,
+            CodeNode,
+        ]
+        expected_contents = [
+            self.filename,
+            "FOO",
+            "foo",
+            "BAR",
+            "bar",
+            "else",
+            "baz",
+            "endif",
+            "qux",
+        ]
+        for i, node in enumerate(self.tree.walk()):
+            self.assertTrue(isinstance(node, expected_types[i]))
+            if isinstance(node, CodeNode):
+                contents = node.spelling()[0]
+            else:
+                contents = str(node)
+            self.assertTrue(expected_contents[i] in contents)
+
+    def test_visit_types(self):
+        """Check that visit() validates inputs"""
+
+        class valid_visitor:
+            def __call__(self, node):
+                return True
+
+        self.tree.visit(valid_visitor())
+
+        def visitor_function(node):
+            return True
+
+        self.tree.visit(visitor_function)
+
+        with self.assertRaises(TypeError):
+            self.tree.visit(1)
+
+        class invalid_visitor:
+            pass
+
+        with self.assertRaises(TypeError):
+            self.tree.visit(invalid_visitor())
+
+    def test_visit(self):
+        """Check that visit() visits nodes as expected"""
+
+        # Check that a trivial visitor visits all nodes.
+        class NodeCounter:
+            def __init__(self):
+                self.count = 0
+
+            def __call__(self, node):
+                self.count += 1
+
+        node_counter = NodeCounter()
+        self.tree.visit(node_counter)
+        self.assertEqual(node_counter.count, 9)
+
+        # Check that returning NEXT_SIBLING prevents descent.
+        class TopLevelCounter:
+            def __init__(self):
+                self.count = 0
+
+            def __call__(self, node):
+                if not isinstance(node, FileNode):
+                    self.count += 1
+                if isinstance(node, DirectiveNode):
+                    return Visit.NEXT_SIBLING
+                return Visit.NEXT
+
+        top_level_counter = TopLevelCounter()
+        self.tree.visit(top_level_counter)
+        self.assertEqual(top_level_counter.count, 5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
The new `visit()` function:
- Passes each node as an argument to the specified callable.
- Decides which node to visit next based on the return type.

The return types are an enum; the values in this enum may need to be extended in order to support additional functionality.

# Related issues

Part of #101.  `visit()` will be used to implement replacements for the remaining classes from the `walkers/` module.

# Proposed changes

<!--
List out, with high level descriptions, what the commits within this pull
request do.
-->

- Add `visit()` functions to `Node` and `SourceTree`, which invoke the specified callable.
- Add tests for different visitor types, including validation tests.
- Add tests for `Visit.NEXT` and `Visit.NEXT_SIBLING` behavior.
