### PR TITLE
Ensure main() catches all exceptions

### DIFF
--- a/codebasin/__main__.py
+++ b/codebasin/__main__.py
@@ -149,7 +149,7 @@ class WarningAggregator(logging.Filter):
             meta_warning.warn()
 
 
-def main():
+def _main():
     # Read command-line arguments
     parser = argparse.ArgumentParser(
         description="Code Base Investigator " + str(version),
@@ -359,10 +359,14 @@ def main():
     sys.exit(0)
 
 
-if __name__ == "__main__":
+def main():
     try:
-        sys.argv[0] = "codebasin"
-        main()
+        _main()
     except Exception as e:
         log.error(str(e))
         sys.exit(1)
+
+
+if __name__ == "__main__":
+    sys.argv[0] = "codebasin"
+    main()


### PR DESCRIPTION
Previously the exception handling was outside of `main()`, which meant that exceptions were only caught when codebasin was launched as a module (i.e., with `python3 -m codebasin`); the `codebasin` script generated by pyproject.toml did not catch exceptions.

# Related issues

N/A

# Proposed changes

- Add another level of indirection: `main()` calls `_main()` and catches all exceptions.
