### PR TITLE
Remove PlatformMapper from test_duplicates

### DIFF
--- a/tests/duplicates/test_duplicates.py
+++ b/tests/duplicates/test_duplicates.py
@@ -80,8 +80,7 @@ class TestDuplicates(unittest.TestCase):
         expected_setmap = {frozenset(["cpu", "cpu2"]): 1}
 
         state = finder.find(self.rootdir, codebase, configuration)
-        mapper = PlatformMapper(codebase)
-        setmap = mapper.walk(state)
+        setmap = state.get_setmap(codebase)
         self.assertDictEqual(setmap, expected_setmap, "Mismatch in setmap")
 
 


### PR DESCRIPTION
This somehow slipped through the cracks when #120 was merged, and wasn't identified until the CI tests ran on the merge commit.

# Related issues

Part of #101. Fixes post-merge failure after #120.

# Proposed changes

- Remove `PlatformMapper` from `test_duplicates`, which was somehow missed.
