### PR TITLE
Remove legacy_warnings

### DIFF
--- a/codebasin/__main__.py
+++ b/codebasin/__main__.py
@@ -319,7 +319,6 @@ def _main():
         rootdir,
         codebase,
         configuration,
-        legacy_warnings=False,
         show_progress=True,
     )
 

--- a/codebasin/finder.py
+++ b/codebasin/finder.py
@@ -112,7 +112,6 @@ def find(
     configuration,
     *,
     summarize_only=True,
-    legacy_warnings=True,
     show_progress=False,
 ):
     """
@@ -130,13 +129,6 @@ def find(
     filenames = set(codebase)
     for p in configuration:
         for e in configuration[p]:
-            if e["file"] not in codebase:
-                filename = e["file"]
-                if legacy_warnings:
-                    log.warning(
-                        f"{filename} found in definition of platform {p} "
-                        + "but missing from codebase",
-                    )
             filenames.add(e["file"])
     for f in tqdm(
         filenames,


### PR DESCRIPTION
This option was originally added when there was a need to support both the YAML and TOML input files. Now that YAML support has been removed, we no longer need this option.

# Related issues

N/A.

# Proposed changes

- Remove the `legacy_warnings` option from the `find()` function.