### PR TITLE
Fix associate() handling of #include from symlink

### DIFF
--- a/codebasin/finder.py
+++ b/codebasin/finder.py
@@ -117,7 +117,7 @@ class ParserState:
             association[node].add(platform.name)
             active = node.evaluate_for_platform(
                 platform=platform,
-                filename=filename,
+                filename=self._get_realpath(filename),
                 state=self,
             )
 


### PR DESCRIPTION
# Related issues

Fixes a bug inadvertently introduced by #125, which I found in offline stress-testing.

# Proposed changes

- Add a regression test for the problematic case.
- Fix the bug in `associate()` by ensuring we call `realpath` before passing filenames to `evaluate_for_platform`.
