### PR TITLE
Improve tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ portability and maintainability of an application's source code.
 - Python 3
 - PyYAML
 - SciPy
+- tabulate
 - tqdm
 
 

--- a/codebasin/report.py
+++ b/codebasin/report.py
@@ -66,7 +66,7 @@ def summary(setmap):
     data = []
     total_count = 0
     for pset in sorted(setmap.keys(), key=len):
-        name = "{" + ", ".join(pset) + "}"
+        name = "{" + ", ".join(sorted(pset)) + "}"
         count = setmap[pset]
         percent = (float(setmap[pset]) / float(total)) * 100
         data += [[name, str(count), f"{percent:.2f}"]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
   "pyyaml==6.0.1",
   "scipy==1.12.0",
   "jsonschema==4.21.1",
+  "tabulate==0.9.0",
   "tqdm==4.66.5",
 ]
 


### PR DESCRIPTION
# Related issues

N/A

# Proposed changes

- Replace use of our custom `report.table` function with `tabulate.table`.
- Prevent non-determinism in table output (which I noticed when testing this new table functionality).

---

See below for an example of the change when running the sample code base.

### Before
```
------------------------
Platform Set  LOC % LOC
------------------------
          {} 2661 98.37
       {cpu}    8  0.30
       {gpu}    8  0.30
  {gpu, cpu}   28  1.04
------------------------
```

**NB**: "gpu" appears before "cpu" in the final set.  This is non-deterministic.

### After
```
┌────────────────┬───────┬─────────┐
│   Platform Set │   LOC │   % LOC │
├────────────────┼───────┼─────────┤
│             {} │  2661 │   98.37 │
├────────────────┼───────┼─────────┤
│          {cpu} │     8 │    0.30 │
├────────────────┼───────┼─────────┤
│          {gpu} │     8 │    0.30 │
├────────────────┼───────┼─────────┤
│     {cpu, gpu} │    28 │    1.04 │
└────────────────┴───────┴─────────┘
```

**NB**: "cpu" now always appears before "gpu" in the final set.