### PR TITLE
Fix definition and implementation of divergence

### DIFF
--- a/codebasin/report.py
+++ b/codebasin/report.py
@@ -77,7 +77,7 @@ def divergence(setmap):
         npairs += 1
 
     if npairs == 0:
-        return 0
+        return float("nan")
     return d / float(npairs)
 
 

--- a/docs/source/specialization.rst
+++ b/docs/source/specialization.rst
@@ -57,7 +57,7 @@ pairwise distances:
 
 .. math::
     CD(a, p, H) = \binom{|H|}{2}^{-1}
-                  \sum_{\{i, j\} \in H \times H} {d_{i, j}(a, p)}
+                  \sum_{\{i, j\} \in \binom{H}{2}} {d_{i, j}(a, p)}
 
 where :math:`d_{i, j}(a, p)` represents the distance between the source
 code required by platforms :math:`i` and :math:`j` for application

--- a/tests/metrics/test_divergence.py
+++ b/tests/metrics/test_divergence.py
@@ -1,0 +1,49 @@
+# Copyright (C) 2019-2024 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+
+import logging
+import math
+import unittest
+import warnings
+
+from codebasin.report import divergence
+
+
+class TestDivergence(unittest.TestCase):
+    """
+    Test computation of code divergence.
+    """
+
+    def setUp(self):
+        logging.disable()
+        warnings.simplefilter("ignore", ResourceWarning)
+
+    def test_divergence(self):
+        """Check divergence computation for simple setmap."""
+        setmap = {
+            frozenset(["A"]): 1,
+            frozenset(["B"]): 2,
+            frozenset(["A", "B"]): 3,
+            frozenset([]): 4,
+        }
+        intersection = 3
+        union = 1 + 2 + 3
+
+        expected_divergence = intersection / union
+        self.assertEqual(divergence(setmap), expected_divergence)
+
+    def test_null_divergence(self):
+        """Check divergence computation for null cases."""
+        setmap = {
+            frozenset(""): 0,
+        }
+        self.assertTrue(math.isnan(divergence(setmap)))
+
+        setmap = {
+            frozenset("A"): 1,
+        }
+        self.assertTrue(math.isnan(divergence(setmap)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
In the original paper, Harrell and Kitson define code divergence imprecisely in terms of pairs (i, j) in a set. In our follow-up "Navigating P3" paper, we attempted to make this more precise and in so doing introduced an error. Specifically, we defined code divergence as drawing all pairs {i, j} from the cartesian product H x H, which would have included {i, j} and {j, i}.

The computation of code divergence in Code Base Investigator was mostly correct, but the incorrect notation was copied into the documentation. The implementation also included a small bug, in that it evaluated the divergence for the empty set and single-item sets as 0 instead of NaN.

These issues were discovered while attempting to rewrite the divergence() routine, and so this commit adds some regression tests to ensure that divergence() produces the correct results.

# Related issues

N/A

# Proposed changes

- Fixes `divergence()` by returning NaN for the empty set or sets containing a single platform.
- Fix the notation in the documentation, by replacing the cartesian product with k-subset notation.
- Add some simple regression tests for divergence calculations.

---

As an aside, to provide a bit more context: I was trying to reimplement `divergence()` in such a way that it would naturally return a 0 when computing the divergence between a platform and itself, and convinced myself that we could in fact iterate over all pairs in the cartesian product because the distance metric is pairwise-symmetric.  Unfortunately that doesn't work, because every time a platform is paired with itself, it adds 0 to the numerator and 1 to the denominator.

I decided that the correct thing to return from this function for now is NaN, because that's consistent with the math.  If we wanted to return something else, we'd need to update the math, and I'm not sure how to justify that at this point.  Returning NaN will encourage us to be more precise in our future work, because we will be forced to confront that we have defined code divergence as an average pairwise distance.