### PR TITLE
Add duplicates report

### DIFF
--- a/codebasin/__main__.py
+++ b/codebasin/__main__.py
@@ -190,7 +190,7 @@ def _main():
         metavar="<report>",
         action="append",
         default=[],
-        choices=["all", "summary", "clustering"],
+        choices=["all", "summary", "clustering", "duplicates"],
         help=_help_string(
             "Generate a report of the specified type.",
             "May be specified multiple times.",
@@ -349,6 +349,10 @@ def _main():
         clustering = report.clustering(clustering_output_name, setmap)
         if clustering is not None:
             print(clustering)
+
+    # Print duplicates report
+    if report_enabled("duplicates"):
+        report.duplicates(codebase)
 
     sys.exit(0)
 

--- a/codebasin/report.py
+++ b/codebasin/report.py
@@ -249,13 +249,15 @@ def find_duplicates(codebase: CodeBase) -> list[set[Path]]:
         A list of all sets of Paths with identical contents.
     """
     # Search for possible matches using a hash, ignoring symlinks.
-    possible_matches = defaultdict(set)
+    possible_matches = {}
     for path in codebase:
         path = Path(path)
         if path.is_symlink():
             continue
         with open(path, "rb") as f:
             digest = hashlib.file_digest(f, "sha512").hexdigest()
+        if digest not in possible_matches:
+            possible_matches[digest] = set()
         possible_matches[digest].add(path)
 
     # Confirm equality for files with the same hash.

--- a/codebasin/report.py
+++ b/codebasin/report.py
@@ -262,14 +262,14 @@ def find_duplicates(codebase: CodeBase) -> list[set[Path]]:
 
     # Confirm equality for files with the same hash.
     confirmed_matches = []
-    for digest, paths in possible_matches.items():
+    for digest, path_set in possible_matches.items():
         # Skip files with no hash conflicts.
-        if len(paths) == 1:
+        if len(path_set) == 1:
             continue
 
         # Check for equality amongst all files in the set.
         # Iterate until we have identified all conflicting hashes.
-        remaining = paths.copy()
+        remaining = path_set.copy()
         while len(remaining) > 1:
             first = remaining.pop()
             matches = {first}

--- a/codebasin/report.py
+++ b/codebasin/report.py
@@ -8,9 +8,11 @@ import filecmp
 import hashlib
 import itertools as it
 import logging
+import sys
 import warnings
 from collections import defaultdict
 from pathlib import Path
+from typing import TextIO
 
 from tabulate import tabulate
 
@@ -277,3 +279,30 @@ def find_duplicates(codebase: CodeBase) -> list[set[Path]]:
                 confirmed_matches.append(matches)
 
     return confirmed_matches
+
+
+def duplicates(codebase: CodeBase, stream: TextIO = sys.stdout):
+    """
+    Produce a report identifying sets of duplicate files.
+
+    Parameters
+    ----------
+    codebase: CodeBase
+        The code base to search for duplicates.
+
+    stream: TextIO, default: sys.stdout
+        The stream to write the report to.
+    """
+    confirmed_matches = find_duplicates(codebase)
+
+    print("Duplicates", file=stream)
+    print("----------", file=stream)
+
+    if len(confirmed_matches) == 0:
+        print("No duplicates found.", file=stream)
+        return
+
+    for i, matches in enumerate(confirmed_matches):
+        print(f"Match {i}:", file=stream)
+        for path in matches:
+            print(f"- {path}")

--- a/docs/source/cmd.rst
+++ b/docs/source/cmd.rst
@@ -30,7 +30,8 @@ Command Line Interface
 
     - ``summary``: output only code divergence information.
     - ``clustering``: output only distance matrix and dendrogram.
-    - ``all``: generate both summary and clustering reports.
+    - ``duplicates``: output only detected duplicate files.
+    - ``all``: generate all available reports.
 
 ``-x <pattern>, --exclude <pattern>``
     Exclude files matching this pattern from the code base.

--- a/tests/duplicates/test_duplicates.py
+++ b/tests/duplicates/test_duplicates.py
@@ -134,6 +134,20 @@ class TestDuplicates(unittest.TestCase):
 
         tmp.cleanup()
 
+    def test_find_duplicates_symlinks(self):
+        """Check that we ignore symlinks when identifying duplicates."""
+        tmp = tempfile.TemporaryDirectory()
+        path = Path(tmp.name)
+        with open(path / "foo.cpp", mode="w") as f:
+            f.write("void foo();")
+        os.symlink(path / "foo.cpp", path / "bar.cpp")
+        codebase = CodeBase(path)
+
+        duplicates = find_duplicates(codebase)
+        self.assertEqual(duplicates, [])
+
+        tmp.cleanup()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/duplicates/test_duplicates.py
+++ b/tests/duplicates/test_duplicates.py
@@ -8,6 +8,7 @@ import unittest
 from pathlib import Path
 
 from codebasin import CodeBase, finder
+from codebasin.report import find_duplicates
 
 
 class TestDuplicates(unittest.TestCase):
@@ -116,6 +117,20 @@ class TestDuplicates(unittest.TestCase):
         state = finder.find(self.rootdir, codebase, configuration)
         setmap = state.get_setmap(codebase)
         self.assertDictEqual(setmap, expected_setmap, "Mismatch in setmap")
+
+    def test_find_duplicates(self):
+        """Check that we can correctly identify duplicate files."""
+        tmp = tempfile.TemporaryDirectory()
+        path = Path(tmp.name)
+        with open(path / "foo.cpp", mode="w") as f:
+            f.write("void foo();")
+        with open(path / "bar.cpp", mode="w") as f:
+            f.write("void foo();")
+        codebase = CodeBase(path)
+
+        duplicates = find_duplicates(codebase)
+        expected_duplicates = [{path / "foo.cpp", path / "bar.cpp"}]
+        self.assertCountEqual(duplicates, expected_duplicates)
 
         tmp.cleanup()
 


### PR DESCRIPTION
Now that we correctly count the contribution of different files with duplicate contents towards code divergence, identifying such files provides an actionable way to improve code base structure (e.g., by using a symlink, or only using one version of the file).
 
For a more detailed history of duplicate detection, see: #72, #79, #116, #122, #131, #133

# Related issues

Closes #84.

# Proposed changes

- Add `find_duplicates` function to search a `CodeBase` for duplicate files.
- Add `duplicates` report to print a summary of `find_duplicates` results when running `codebasin`.
- Add tests for `find_duplicates` on simple code bases.

---

With my offline stress-test (which has about 1000 source files and 400k SLOC), enabling this new functionality has no appreciable impact on execution time.  It found a bunch of duplicate files that I didn't know about, and produces the report below:

```
Duplicates
----------
Match 0:
- /path/to/code-base/cpu/common.h
- /path/to/code-base/opencl/common.h
- /path/to/code-base/sycl/common.h
- /path/to/code-base/cuda/common.h
Match 1:
- /path/to/code-base/dfft/old/fp.h
- /path/to/code-base/dfft/programs/fp.h
```
