### PR TITLE
Add files report

### DIFF
--- a/codebasin/__main__.py
+++ b/codebasin/__main__.py
@@ -190,7 +190,7 @@ def _main():
         metavar="<report>",
         action="append",
         default=[],
-        choices=["all", "summary", "clustering", "duplicates"],
+        choices=["all", "summary", "clustering", "duplicates", "files"],
         help=_help_string(
             "Generate a report of the specified type.",
             "May be specified multiple times.",
@@ -338,6 +338,10 @@ def _main():
         summary = report.summary(setmap)
         if summary is not None:
             print(summary)
+
+    # Print files report
+    if report_enabled("files"):
+        report.files(codebase, state)
 
     # Print clustering report
     if report_enabled("clustering"):

--- a/codebasin/report.py
+++ b/codebasin/report.py
@@ -750,6 +750,15 @@ def files(
         label = string.ascii_uppercase[i]
         legend += [f"\033[33m{label}\033[0m: {platform}"]
     legend += [""]
+    legend += ["\033[1mColumns\033[0m:"]
+    header = [
+        "Platform Set",
+        "Used SLOC / Total SLOC",
+        "Code Divergence",
+        "Code Utilization",
+    ]
+    legend += ["[" + " | ".join(header) + "]"]
+    legend += [""]
     legend = "\n".join(legend)
     if not stream.isatty():
         legend = _strip_colors(legend)

--- a/codebasin/report.py
+++ b/codebasin/report.py
@@ -346,7 +346,7 @@ def _human_readable(x: int) -> str:
         return f"{x/10**6:.1f}M"
     elif digits <= 12:
         return f"{x/10**9:.1f}G"
-    return "??????"
+    return "******"
 
 
 def _strip_colors(s: str) -> str:

--- a/codebasin/report.py
+++ b/codebasin/report.py
@@ -8,15 +8,22 @@ import filecmp
 import hashlib
 import itertools as it
 import logging
+import numbers
+import os
+import re
+import string
 import sys
 import warnings
 from collections import defaultdict
+from collections.abc import Iterable
 from pathlib import Path
-from typing import TextIO
+from typing import Self, TextIO
 
 from tabulate import tabulate
 
 from codebasin import CodeBase, util
+from codebasin.finder import ParserState
+from codebasin.preprocessor import CodeNode
 
 log = logging.getLogger(__name__)
 
@@ -308,3 +315,445 @@ def duplicates(codebase: CodeBase, stream: TextIO = sys.stdout):
         print(f"Match {i}:", file=stream)
         for path in matches:
             print(f"- {path}")
+
+
+def _human_readable(x: int) -> str:
+    """
+    Parameters
+    ----------
+    x: int
+        An integer.
+
+    Returns
+    -------
+    str
+        A human-readable representation of x.
+
+    Raises
+    ------
+    TypeError
+        If `x` is not an integer.
+    """
+    if not isinstance(x, numbers.Integral):
+        raise TypeError("x must be Integral")
+
+    digits = len(str(x))
+    if digits <= 3:
+        return str(x)
+    elif digits <= 6:
+        return f"{x/10**3:.1f}k"
+    elif digits <= 9:
+        return f"{x/10**6:.1f}M"
+    elif digits <= 12:
+        return f"{x/10**9:.1f}G"
+    return "??????"
+
+
+def _strip_colors(s: str) -> str:
+    """
+    Strip ASCII color codes from a string.
+
+    Parameters
+    ----------
+    s: str
+        The string to strip color codes from.
+
+    Returns
+    -------
+    str
+        A copy of s with all color codes removed.
+
+    Raises
+    ------
+    TypeError
+        If `s` is not a string.
+    """
+    if not isinstance(s, str):
+        raise TypeError("s must be a string")
+
+    return re.sub(r"\033\[[0-9]*m", "", s)
+
+
+class FileTree:
+    """
+    A FileTree represents all of the files in a directory using a tree
+    structure, with hierarchical tracking of the platform set used by
+    each file and directory.
+    """
+
+    class Node:
+        """
+        A FileTree.Node represents a single file or directory in a FileTree.
+        """
+
+        def __init__(
+            self,
+            path,
+            setmap=None,
+            is_root=False,
+        ):
+            self.path = Path(path)
+            if setmap is None:
+                setmap = defaultdict(int)
+            self.setmap = setmap
+            self.children = {}
+            self.is_root = is_root
+
+        @property
+        def name(self):
+            if self.is_root:
+                return str(self.path)
+            return str(self.path.name)
+
+        @property
+        def platforms(self):
+            return extract_platforms(self.setmap)
+
+        @property
+        def sloc(self):
+            count = 0
+            for k, v in self.setmap.items():
+                if len(k) == 0:
+                    continue
+                count += v
+            return count
+
+        def is_dir(self):
+            return self.path.is_dir()
+
+        def is_symlink(self):
+            return self.path.is_symlink()
+
+        def _platforms_str(
+            self,
+            all_platforms: set[str],
+            labels: Iterable[str] = string.ascii_uppercase,
+        ) -> str:
+            """
+            Parameters
+            ----------
+            all_platforms: set[str]
+                The set of all platforms.
+
+            labels: Iterable[str], default: string.ascii_uppercase
+                The labels to use in place of real platform names.
+
+            Returns
+            -------
+            str
+                A string representing the platforms used by this Node.
+            """
+            output = ""
+            for i, platform in enumerate(sorted(all_platforms)):
+                if platform in self.platforms:
+                    if self.is_symlink():
+                        color = "\033[96m"
+                    else:
+                        color = "\033[33m"
+                    value = labels[i]
+                else:
+                    color = "\033[2m"
+                    value = "-"
+                output += f"{color}{value}\033[0m"
+            return output
+
+        def _sloc_str(self, max_used: int, max_total: int) -> str:
+            """
+            Parameters
+            ----------
+            max_used: int
+                The maximum used SLOC, used to determine formatting width.
+
+            max_total: int
+                The maximum total SLOC, used to determine formatting width.
+
+            Returns
+            -------
+            str
+                A string representing the SLOC used by this Node, in the form
+                "used / total" with human-readable numbers.
+            """
+            color = ""
+            if len(self.platforms) == 0:
+                color = "\033[2m"
+            elif self.is_symlink():
+                color = "\033[96m"
+
+            used_len = len(_human_readable(max_used))
+            total_len = len(_human_readable(max_total))
+
+            used = _human_readable(self.sloc)
+            total = _human_readable(sum(self.setmap.values()))
+
+            return f"{color}{used:>{used_len}} / {total:>{total_len}}\033[0m"
+
+        def _divergence_str(self) -> str:
+            """
+            Returns
+            -------
+            str
+                A string representing code divergence in this Node.
+            """
+            cd = divergence(self.setmap)
+            color = ""
+            if len(self.platforms) == 0:
+                color = "\033[2m"
+            elif self.is_symlink():
+                color = "\033[96m"
+            elif cd <= 0.25:
+                color = "\033[32m"
+            elif cd >= 0.75 or len(self.platforms) == 1:
+                color = "\033[35m"
+            return f"{color}{cd:4.2f}\033[0m"
+
+        def _utilization_str(self, total_platforms: int) -> str:
+            """
+            Parameters
+            ----------
+            total_platforms: int
+                The number of platforms in the whole FileTree.
+
+            Returns
+            -------
+            str
+                A string representing code utilization in this Node.
+            """
+            nu = normalized_utilization(self.setmap, total_platforms)
+
+            color = ""
+            if len(self.platforms) == 0:
+                color = "\033[2m"
+            elif self.is_symlink():
+                color = "\033[96m"
+            elif nu > 0.5:
+                color = "\033[32m"
+            elif nu <= 0.5:
+                color = "\033[35m"
+
+            return f"{color}{nu:4.2f}\033[0m"
+
+        def _meta_str(self, root: Self) -> str:
+            """
+            Parameters
+            ----------
+            root: FileTree.Node
+                The root of the FileTree containing this FileTree.Node.
+
+            Returns
+            -------
+            str
+                A string representing meta-information for this FileTree.Node.
+            """
+            max_used = root.sloc
+            max_total = sum(root.setmap.values())
+            info = [
+                self._platforms_str(root.platforms),
+                self._sloc_str(max_used, max_total),
+                self._divergence_str(),
+                self._utilization_str(len(root.platforms)),
+            ]
+            return "[" + " | ".join(info) + "]"
+
+    def __init__(self, rootdir: str | os.PathLike[str]):
+        self.root = FileTree.Node(rootdir, is_root=True)
+
+    def insert(
+        self,
+        filename: str | os.PathLike[str],
+        setmap: defaultdict[str, int],
+    ):
+        """
+        Insert a new file into the tree, creating as many nodes as necessary.
+
+        Parameters
+        ----------
+        filename: str | os.PathLike[str]
+            The filename to add to the tree.
+
+        setmap: dict | None
+            The setmap information associated with this filename.
+        """
+        rootpath = self.root.path
+        filepath = Path(filename)
+
+        parent = self.root
+        for path in list(reversed(filepath.parents)) + [filepath]:
+            # Do not create nodes above the chosen root directory.
+            if path == rootpath or not path.is_relative_to(rootpath):
+                continue
+
+            # Do not propagate information from symlinks.
+            if not filepath.is_symlink():
+                for ps in setmap.keys():
+                    parent.setmap[ps] += setmap[ps]
+
+            # If this name exists, find the node.
+            if parent is not None and path.name in parent.children:
+                node = parent.children[path.name]
+
+            # Otherwise, create the node.
+            else:
+                if not path.is_dir():
+                    node = FileTree.Node(path, setmap)
+                else:
+                    node = FileTree.Node(path)
+                parent.children[path.name] = node
+
+            parent = node
+
+    def _print(
+        self,
+        node: Node,
+        prefix: str = "",
+        connector: str = "",
+        fancy: bool = True,
+    ):
+        """
+        Recursive helper function to print all nodes in a FileTree.
+
+        Parameters
+        ----------
+        node: Node
+            The current FileTree.Node to print.
+
+        prefix: str, default: ""
+            The current prefix, built up from previous recursive calls.
+
+        connector: str, default: ""
+            The character used to connect this Node to the FileTree.
+
+        fancy: bool, default: True
+            Whether to use fancy formatting (including colors).
+        """
+        if fancy:
+            dash = "\u2500"
+            cont = "\u251C"
+            last = "\u2514"
+            vert = "\u2502"
+        else:
+            dash = "-"
+            cont = "|"
+            last = "\\"
+            vert = "|"
+
+        lines = []
+
+        name = ""
+        if node.is_dir():
+            name += "\033[94m"
+        elif node.is_symlink():
+            name += "\033[96m"
+        elif len(node.platforms) == 0:
+            name += "\033[2m"
+        name += node.name
+        if node.is_dir():
+            name += os.sep
+        if node.is_symlink():
+            name += "\033[0m"
+            name += " -> " + str(node.path.resolve())
+
+        name += "\033[0m"
+
+        meta = node._meta_str(self.root)
+
+        # Print this node.
+        stub = "" if node == self.root else dash
+        stub += "o" if node.is_dir() else dash
+        lines += [f"{meta} {prefix}{connector}{stub} {name}"]
+
+        # Prefix children with spaces or vertical line, depending on position.
+        if connector == "":
+            next_prefix = ""
+        elif connector == last:
+            next_prefix = prefix + "  "
+        else:
+            next_prefix = prefix + vert + " "
+
+        for i, name in enumerate(node.children):
+            # Use a different connector for the last child in each directory.
+            if i == len(node.children) - 1:
+                next_connector = last
+            else:
+                next_connector = cont
+            lines += self._print(
+                node.children[name],
+                next_prefix,
+                next_connector,
+                fancy,
+            )
+
+        return lines
+
+    def write_to(self, stream: TextIO):
+        """
+        Write the FileTree to the specified stream.
+
+        Parameters
+        ----------
+        stream: TextIO
+            The text stream to write to.
+        """
+        lines = self._print(self.root, fancy=stream.isatty())
+        output = "\n".join(lines)
+        if not stream.isatty():
+            output = _strip_colors(output)
+        print(output, file=stream)
+
+
+def files(
+    codebase: CodeBase,
+    state: ParserState | None = None,
+    stream: TextIO = sys.stdout,
+):
+    """
+    Produce a file tree representing the code base.
+
+    Parameters
+    ----------
+    codebase: CodeBase
+        The code base to visualize as a tree.
+
+    state: ParserState, default: None
+        An optional ParserState used to annotate the tree with platform
+        information.
+
+    stream: TextIO, default: sys.stdout
+        The stream to write the report to.
+
+    Raises
+    ------
+    NotImplementedError
+        If the number of directories in the code base is not 1.
+    """
+    if len(codebase.directories) != 1:
+        raise NotImplementedError(
+            "'files' report currently requires a code base with 1 directory.",
+        )
+
+    # Build up a tree from the list of files.
+    tree = FileTree(codebase.directories[0])
+    for f in codebase:
+        setmap = defaultdict(int)
+        if state:
+            for node, assoc in state.get_map(f).items():
+                if isinstance(node, CodeNode):
+                    setmap[frozenset(assoc)] += node.num_lines
+        tree.insert(f, setmap)
+
+    print("Files", file=stream)
+    print("-----", file=stream)
+
+    # Print a legend.
+    legend = []
+    legend += ["\033[1mLegend\033[0m:"]
+    for i, platform in enumerate(sorted(tree.root.platforms)):
+        label = string.ascii_uppercase[i]
+        legend += [f"\033[33m{label}\033[0m: {platform}"]
+    legend += [""]
+    legend = "\n".join(legend)
+    if not stream.isatty():
+        legend = _strip_colors(legend)
+    print(legend, file=stream)
+
+    # Print the tree.
+    tree.write_to(stream)

--- a/docs/source/cmd.rst
+++ b/docs/source/cmd.rst
@@ -31,6 +31,7 @@ Command Line Interface
     - ``summary``: output only code divergence information.
     - ``clustering``: output only distance matrix and dendrogram.
     - ``duplicates``: output only detected duplicate files.
+    - ``files``: output only information about individual files.
     - ``all``: generate all available reports.
 
 ``-x <pattern>, --exclude <pattern>``

--- a/tests/files/__init__.py
+++ b/tests/files/__init__.py
@@ -1,0 +1,2 @@
+# Copyright (C) 2019-2024 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause

--- a/tests/files/test_filetree.py
+++ b/tests/files/test_filetree.py
@@ -1,0 +1,99 @@
+# Copyright (C) 2019-2024 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+
+import logging
+import os
+import tempfile
+import unittest
+import warnings
+from pathlib import Path
+
+from codebasin.report import FileTree
+
+
+class TestFileTree(unittest.TestCase):
+    """
+    Test FileTree functionality.
+    """
+
+    def setUp(self):
+        logging.disable()
+        warnings.simplefilter("ignore", ResourceWarning)
+
+        self.setmap = {
+            frozenset(["X"]): 1,
+            frozenset(["Y"]): 2,
+            frozenset(["X", "Y"]): 3,
+            frozenset([]): 6,
+        }
+
+        self.tmp = tempfile.TemporaryDirectory()
+        self.path = Path(self.tmp.name)
+        open(self.path / "file.cpp", mode="w").close()
+        open(self.path / "other.cpp", mode="w").close()
+        os.symlink(self.path / "file.cpp", self.path / "symlink.cpp")
+
+    def test_constructor(self):
+        """Check FileTree constructor."""
+        tree = FileTree(self.path)
+        self.assertEqual(tree.root.path, self.path)
+        self.assertTrue(tree.root.is_root)
+
+    def test_insert(self):
+        """Check insertion into FileTree."""
+        tree = FileTree(self.path)
+
+        tree.insert(self.path / "file.cpp", setmap={"X": 1})
+        self.assertEqual(len(tree.root.children), 1)
+        self.assertCountEqual(tree.root.platforms, ["X"])
+        self.assertEqual(tree.root.setmap, {"X": 1})
+        self.assertEqual(tree.root.sloc, 1)
+
+        # NB: information from symlinks doesn't propagate upwards!
+        tree.insert(self.path / "symlink.cpp", setmap={"Y": 2})
+        self.assertEqual(len(tree.root.children), 2)
+        self.assertCountEqual(tree.root.platforms, ["X"])
+        self.assertEqual(tree.root.setmap, {"X": 1})
+        self.assertEqual(tree.root.sloc, 1)
+
+        tree.insert(self.path / "other.cpp", setmap={"Y": 2})
+        self.assertEqual(len(tree.root.children), 3)
+        self.assertCountEqual(tree.root.platforms, ["X", "Y"])
+        self.assertEqual(tree.root.setmap, {"X": 1, "Y": 2})
+        self.assertEqual(tree.root.sloc, 3)
+
+        children_names = [node for node in tree.root.children]
+        expected_names = ["file.cpp", "symlink.cpp", "other.cpp"]
+        self.assertCountEqual(children_names, expected_names)
+        self.assertFalse(tree.root.children["file.cpp"].is_symlink())
+        self.assertFalse(tree.root.children["other.cpp"].is_symlink())
+        self.assertTrue(tree.root.children["symlink.cpp"].is_symlink())
+
+    def test_print(self):
+        """Check print for specific cases."""
+        tree = FileTree(self.path)
+        meta = tree.root._meta_str(tree.root)
+        lines = tree._print(tree.root)
+        self.assertEqual(lines, [f"{meta} o \033[94m{self.path}/\033[0m"])
+
+        tree.insert(self.path / "file.cpp", setmap={"X": 1})
+        node = tree.root.children["file.cpp"]
+        meta = node._meta_str(tree.root)
+        lines = tree._print(node)
+        self.assertEqual(lines, [f"{meta} \u2500\u2500 file.cpp\033[0m"])
+
+        tree.insert(self.path / "symlink.cpp", setmap={"Y": 2})
+        node = tree.root.children["symlink.cpp"]
+        self.assertTrue(node.is_symlink())
+        meta = node._meta_str(tree.root)
+        lines = tree._print(node)
+        expected_name = "\033[96msymlink.cpp\033[0m"
+        expected_link = f"{str(self.path / 'file.cpp')}\033[0m"
+        self.assertEqual(
+            lines,
+            [f"{meta} \u2500\u2500 {expected_name} -> {expected_link}"],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/files/test_filetree_node.py
+++ b/tests/files/test_filetree_node.py
@@ -1,0 +1,158 @@
+# Copyright (C) 2019-2024 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+
+import logging
+import os
+import tempfile
+import unittest
+import warnings
+from collections import defaultdict
+from pathlib import Path
+
+from codebasin.report import FileTree, divergence, normalized_utilization
+
+
+class TestFileTreeNode(unittest.TestCase):
+    """
+    Test FileTree.Node functionality.
+    """
+
+    def setUp(self):
+        logging.disable()
+        warnings.simplefilter("ignore", ResourceWarning)
+
+        self.setmap = {
+            frozenset(["X"]): 1,
+            frozenset(["Y"]): 2,
+            frozenset(["X", "Y"]): 3,
+            frozenset([]): 6,
+        }
+
+        self.tmp = tempfile.TemporaryDirectory()
+        self.path = Path(self.tmp.name)
+        open(self.path / "file.cpp", mode="w").close()
+        os.symlink(self.path / "file.cpp", self.path / "symlink.cpp")
+
+    def test_constructor(self):
+        """Check FileTree.Node constructor."""
+        node = FileTree.Node(self.path)
+        self.assertEqual(node.path, self.path)
+        self.assertEqual(node.setmap, defaultdict(int))
+        self.assertEqual(node.children, dict())
+        self.assertFalse(node.is_root)
+        self.assertEqual(node.name, self.path.name)
+        self.assertEqual(node.platforms, [])
+        self.assertEqual(node.sloc, 0)
+        self.assertTrue(node.is_dir())
+        self.assertFalse(node.is_symlink())
+
+        node = FileTree.Node(self.path / "file.cpp")
+        self.assertFalse(node.is_dir())
+
+        node = FileTree.Node(self.path / "symlink.cpp")
+        self.assertFalse(node.is_dir())
+        self.assertTrue(node.is_symlink())
+
+        node = FileTree.Node(self.path, setmap=self.setmap, is_root=True)
+        self.assertEqual(node.setmap, self.setmap)
+        self.assertTrue(node.is_root)
+        self.assertEqual(node.name, str(self.path))
+        self.assertCountEqual(node.platforms, ["X", "Y"])
+        self.assertEqual(node.sloc, 6)
+
+    def test_platforms_str(self):
+        """Check platform string format."""
+        node = FileTree.Node(self.path / "file.cpp", setmap=self.setmap)
+        s = node._platforms_str({"X", "Y"})
+        self.assertEqual(s, "\033[33mA\033[0m\033[33mB\033[0m")
+
+        node = FileTree.Node(self.path / "file.cpp")
+        s = node._platforms_str({"X", "Y"})
+        self.assertEqual(s, "\033[2m-\033[0m\033[2m-\033[0m")
+
+        node = FileTree.Node(self.path / "symlink.cpp", setmap=self.setmap)
+        s = node._platforms_str({"X", "Y"})
+        self.assertEqual(s, "\033[96mA\033[0m\033[96mB\033[0m")
+
+        node = FileTree.Node(
+            self.path / "symlink.cpp",
+            setmap=defaultdict(int),
+        )
+        s = node._platforms_str({"X", "Y"})
+        self.assertEqual(s, "\033[2m-\033[0m\033[2m-\033[0m")
+
+        node = FileTree.Node(self.path / "file.cpp", setmap=self.setmap)
+        s = node._platforms_str({"X", "Y"}, labels=["Q", "R"])
+        self.assertEqual(s, "\033[33mQ\033[0m\033[33mR\033[0m")
+
+    def test_sloc_str(self):
+        """Check SLOC string format."""
+        node = FileTree.Node(self.path / "file.cpp", setmap=self.setmap)
+        s = node._sloc_str(6, 12)
+        self.assertEqual(s, "6 / 12\033[0m")
+
+        s = node._sloc_str(100, 1000)
+        self.assertEqual(s, "  6 /   12\033[0m")
+
+        node = FileTree.Node(self.path / "file.cpp")
+        s = node._sloc_str(6, 12)
+        self.assertEqual(s, "\033[2m0 /  0\033[0m")
+
+        node = FileTree.Node(self.path / "symlink.cpp", setmap=self.setmap)
+        s = node._sloc_str(6, 12)
+        self.assertEqual(s, "\033[96m6 / 12\033[0m")
+
+        node = FileTree.Node(
+            self.path / "symlink.cpp",
+            setmap=defaultdict(int),
+        )
+        s = node._sloc_str(6, 12)
+        self.assertEqual(s, "\033[2m0 /  0\033[0m")
+
+    def test_divergence_str(self):
+        """Check divergence string format."""
+        node = FileTree.Node(self.path / "file.cpp", setmap=self.setmap)
+        cd = divergence(self.setmap)
+        s = node._divergence_str()
+        self.assertEqual(s, f"{cd:4.2f}\033[0m")
+
+        node = FileTree.Node(self.path / "file.cpp")
+        cd = float("nan")
+        s = node._divergence_str()
+        self.assertEqual(s, f"\033[2m{cd:4.2f}\033[0m")
+
+        node = FileTree.Node(self.path / "symlink.cpp", setmap=self.setmap)
+        cd = divergence(self.setmap)
+        s = node._divergence_str()
+        self.assertEqual(s, f"\033[96m{cd:4.2f}\033[0m")
+
+        node = FileTree.Node(self.path / "symlink.cpp")
+        cd = float("nan")
+        s = node._divergence_str()
+        self.assertEqual(s, f"\033[2m{cd:4.2f}\033[0m")
+
+    def test_utilization_str(self):
+        """Check utilization string format."""
+        node = FileTree.Node(self.path / "file.cpp", setmap=self.setmap)
+        nu = normalized_utilization(self.setmap, 2)
+        s = node._utilization_str(2)
+        self.assertEqual(s, f"\033[35m{nu:4.2f}\033[0m")
+
+        node = FileTree.Node(self.path / "file.cpp")
+        nu = float("nan")
+        s = node._utilization_str(2)
+        self.assertEqual(s, f"\033[2m{nu:4.2f}\033[0m")
+
+        node = FileTree.Node(self.path / "symlink.cpp", setmap=self.setmap)
+        nu = normalized_utilization(self.setmap, 2)
+        s = node._utilization_str(2)
+        self.assertEqual(s, f"\033[96m{nu:4.2f}\033[0m")
+
+        node = FileTree.Node(self.path / "symlink.cpp")
+        nu = float("nan")
+        s = node._utilization_str(2)
+        self.assertEqual(s, f"\033[2m{nu:4.2f}\033[0m")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/files/test_filetree_utils.py
+++ b/tests/files/test_filetree_utils.py
@@ -1,0 +1,48 @@
+# Copyright (C) 2019-2024 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+
+import logging
+import unittest
+
+from codebasin.report import _human_readable, _strip_colors
+
+
+class TestFileTreeUtils(unittest.TestCase):
+    """
+    Test FileTree utility/helper functions.
+    """
+
+    def setUp(self):
+        logging.disable()
+
+    def test_human_readable_validation(self):
+        """Check that human_readable rejects non-integers."""
+        with self.assertRaises(TypeError):
+            _ = _human_readable("1")
+
+    def test_human_readable(self):
+        """Check that human_readable produces correct results."""
+        integers = [1, 12, 123, 1234, 12345, 123456, 123456789]
+        strings = ["1", "12", "123", "1.2k", "12.3k", "123.5k", "123.5M"]
+        for i, expected in zip(integers, strings):
+            with self.subTest(i=i, expected=expected):
+                s = _human_readable(i)
+                self.assertEqual(s, expected)
+
+    def test_strip_colors_validation(self):
+        """Check that strip_colors rejects non-strings."""
+        with self.assertRaises(TypeError):
+            _ = _strip_colors(1)
+
+    def test_strip_colors(self):
+        """Check that strip_colors produces correct results."""
+        inputs = ["\033[2mA\033[0m", "\033[1m\033[33mB\033[0m"]
+        expected = ["A", "B"]
+        for s, expected in zip(inputs, expected):
+            with self.subTest(s=s, expected=expected):
+                stripped = _strip_colors(s)
+                self.assertEqual(stripped, expected)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Introduces a new files report that visualizes the entire code base as a tree with a format inspired by the "tree" utility.

Information about the platforms and SLOC used by each node in the tree is printed similar to tree's "metafirst" output, in the format:

```
[Platforms | Used SLOC / Total SLOC | Code Divergence | Code Utilization]
```

Colors and formatting are all hard-coded in this initial version, but the long-term plan is to allow configuration via the .cbi/config file.

# Related issues

N/A

# Proposed changes

- Add a new `FileTree` object to represent a directory of files + associated platform information hierarchically.
- Add a new `files` report that builds a `FileTree` for a `CodeBase` and prints a colored version to the terminal.
- Add a bunch of tests for `FileTree` and associated functionality.

---

@laserkelvin - I can only apologize for this being such a big diff...  The feature proved really complicated to get right, and even after a bunch of refactoring I couldn't really find a good way to split things up for review.  I completely understand if this takes you a while!

---

Here's an example of the current output:

![image](https://github.com/user-attachments/assets/219215bc-0726-44c4-8e15-e5fceecf99f6)


