### PR TITLE
Improve schema validation error messages

### DIFF
--- a/codebasin/__main__.py
+++ b/codebasin/__main__.py
@@ -283,10 +283,7 @@ def _main():
                 raise RuntimeError(f"Analysis file {path} must end in .toml.")
 
         with open(path, "rb") as f:
-            try:
-                analysis_toml = util._load_toml(f, "analysis")
-            except BaseException:
-                raise ValueError("Analysis file failed validation")
+            analysis_toml = util._load_toml(f, "analysis")
 
         if "codebase" in analysis_toml:
             if "exclude" in analysis_toml["codebase"]:

--- a/codebasin/config.py
+++ b/codebasin/config.py
@@ -85,10 +85,11 @@ def load_importcfg():
         with open(path, "rb") as f:
             try:
                 _importcfg_toml = util._load_toml(f, "cbiconfig")
-                for name, compiler in _importcfg_toml["compiler"].items():
-                    _importcfg[name] = compiler["options"]
-            except BaseException:
-                log.error("Configuration file failed validation")
+            except ValueError as e:
+                log.error(str(e))
+                return
+        for name, compiler in _importcfg_toml["compiler"].items():
+            _importcfg[name] = compiler["options"]
 
 
 class Compiler:

--- a/codebasin/util.py
+++ b/codebasin/util.py
@@ -85,7 +85,7 @@ def _validate_json(json_object: object, schema_name: str) -> bool:
         If the JSON fails to validate, or the schema name is unrecognized.
 
     RuntimeError
-        If the schema file cannot be located.
+        If the schema file cannot be located, or the schema is invalid.
     """
     schema_paths = {
         "analysis": "schema/analysis.schema",
@@ -106,8 +106,8 @@ def _validate_json(json_object: object, schema_name: str) -> bool:
 
     try:
         jsonschema.validate(instance=json_object, schema=schema)
-    except jsonschema.exceptions.ValidationError:
-        msg = f"JSON failed schema validation against {schema_path}"
+    except jsonschema.exceptions.ValidationError as e:
+        msg = f"Failed schema validation against {schema_path}: {e.message}"
         raise ValueError(msg)
     except jsonschema.exceptions.SchemaError:
         msg = f"{schema_path} is not a valid schema"


### PR DESCRIPTION
We previously decided to suppress `jsonschema.exceptions.ValidationError` messages because they provided a significant amount of context by default. By extracting the 'message' field, we can provide a helpful error message without also providing full context about the schema.

# Related issues

Closes #67.

# Proposed changes

- Include the 'message' field in the `ValueError` raised by a validation failure.
- Catch `ValueError` explicitly, since catching `BaseException` may hide other failures.
- Fix a small bug in the validation docstring.

---

Before this change, any error in the .cbi/config file produced this error:
```
error: Configuration file failed validation
```

Now, it produces helpful errors:
```
[compiler."c++"]
options = ["-DASDF", 1]
~
error: Failed schema validation against schema/cbiconfig.schema: 1 is not of type 'string'
```
```
[compiler."c++"]
options = "-DASDF"
~                   
error: Failed schema validation against schema/cbiconfig.schema: '-DASDF' is not of type 'array'
```