### PR TITLE
Refactor ensure_ext

### DIFF
--- a/codebasin/report.py
+++ b/codebasin/report.py
@@ -190,7 +190,7 @@ def clustering(output_name, setmap):
         log.error("clustering is not supported for a single platform.")
         return None
 
-    if not util.ensure_png(output_name):
+    if not util.ensure_ext(output_name, ".png"):
         log.error("clustering output file name must end in '.png'.")
         return None
 

--- a/codebasin/report.py
+++ b/codebasin/report.py
@@ -189,10 +189,7 @@ def clustering(output_name, setmap):
     if len(platforms) == 1:
         log.error("clustering is not supported for a single platform.")
         return None
-
-    if not util.ensure_ext(output_name, ".png"):
-        log.error("clustering output file name must end in '.png'.")
-        return None
+    util.ensure_ext(output_name, ".png")
 
     # Import additional modules required by clustering report
     # Force Agg backend to matplotlib to avoid DISPLAY errors

--- a/codebasin/util.py
+++ b/codebasin/util.py
@@ -14,20 +14,49 @@ import pkgutil
 import tomllib
 import typing
 from collections.abc import Iterable
-from os.path import splitext
+from pathlib import Path
 
 import jsonschema
 
 log = logging.getLogger(__name__)
 
 
-def ensure_ext(fname, extensions):
-    """Return true if the path passed in has specified extension"""
-    if not isinstance(extensions, Iterable):
-        extensions = [extensions]
+def ensure_ext(path: os.PathLike[str], extensions: Iterable[str]):
+    """
+    Ensure that a path has one of the specified extensions.
 
-    split = splitext(fname)
-    return len(split) == 2 and split[1].lower() in extensions
+    Parameters
+    ----------
+    path: os.PathLike[str]
+        The path to test.
+
+    extensions: Iterable[str]
+        The valid extensions to test against.
+
+    Returns
+    -------
+    bool
+        True if `path` is a file with one of the specified extensions.
+
+    Raises
+    ------
+    TypeError
+        If `path` is not a string or PathLike.
+        If `extensions` is not a string or an Iterable of strings.
+
+    ValueError
+        If `path` does not have one of the specified extensions.
+    """
+    path = Path(path)
+    if isinstance(extensions, str):
+        extensions = [extensions]
+    if not all(isinstance(ext, str) for ext in extensions):
+        raise TypeError("'extensions' must be 'str' or 'Iterable[str]'")
+
+    extension = "".join(path.suffixes)
+    if extension not in extensions:
+        exts = ", ".join([f"'{ext}'" for ext in extensions])
+        raise ValueError(f"{path} does not have a valid extension: f{exts}")
 
 
 def safe_open_write_binary(fname):

--- a/codebasin/util.py
+++ b/codebasin/util.py
@@ -30,11 +30,6 @@ def ensure_ext(fname, extensions):
     return len(split) == 2 and split[1].lower() in extensions
 
 
-def ensure_png(fname):
-    """Return true if the path passed in specifies a png"""
-    return ensure_ext(fname, ".png")
-
-
 def safe_open_write_binary(fname):
     """Open fname for (binary) writing. Truncate if not a symlink."""
     fpid = os.open(

--- a/tests/util/test_util.py
+++ b/tests/util/test_util.py
@@ -1,0 +1,45 @@
+# Copyright (C) 2019-2024 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+
+import logging
+import unittest
+
+from codebasin.util import ensure_ext
+
+
+class TestUtil(unittest.TestCase):
+    """
+    Test utility functions.
+    """
+
+    def setUp(self):
+        logging.disable()
+
+    def test_ensure_ext_validation(self):
+        """Check ensure_ext raises expected errors"""
+        with self.assertRaises(TypeError):
+            ensure_ext("path.png", 1)
+
+        with self.assertRaises(TypeError):
+            ensure_ext("path.png", [1])
+
+        with self.assertRaises(TypeError):
+            ensure_ext("path.png", [".png", 1])
+
+        with self.assertRaises(TypeError):
+            not_a_path = 1
+            ensure_ext(not_a_path, [".png"])
+
+    def test_ensure_ext(self):
+        """Check ensure_ext correctness"""
+        with self.assertRaises(ValueError):
+            ensure_ext("path.jpg", [".png"])
+
+        ensure_ext("path.png", ".png")
+        ensure_ext("path.png", [".png"])
+        ensure_ext("path.png", [".jpg", ".png"])
+        ensure_ext("path.tar.gz", [".tar.gz"])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Related issues

Part of #36 and #58. 

# Proposed changes

- Refactor `ensure_ext` to use `pathlib`.
- Raise errors directly from `ensure_ext`, so we can't forget to check its return value.
- Add missing docstrings and tests.
