### PR TITLE
Refactor Node using dataclass

### DIFF
--- a/codebasin/file_parser.py
+++ b/codebasin/file_parser.py
@@ -157,7 +157,7 @@ class FileParser:
                 filename = tree.root.filename
                 line = tokens[0].line
                 column = tokens[0].col
-                spelling = preprocessor.toklist_print(tokens)
+                spelling = new_node.spelling()
                 message = f"unrecognized directive '{spelling}'"
                 log.warning(f"{filename}:{line}:{column}: {message}")
 

--- a/tests/parsers/test_directive_parser.py
+++ b/tests/parsers/test_directive_parser.py
@@ -96,34 +96,38 @@ class TestDirectiveParser(unittest.TestCase):
         tokens = preprocessor.Lexer("#if FOO == BAR").tokenize()
         node = preprocessor.DirectiveParser(tokens).parse()
         self.assertTrue(isinstance(node, preprocessor.IfNode))
-        self.assertTrue(len(node.tokens) == 3)
+        self.assertTrue(len(node.tokens) == 5)
+        self.assertTrue(len(node.expr) == 3)
 
     def test_ifdef(self):
         """ifdef"""
         tokens = preprocessor.Lexer("#ifdef FOO").tokenize()
         node = preprocessor.DirectiveParser(tokens).parse()
         self.assertTrue(isinstance(node, preprocessor.IfNode))
-        self.assertTrue(len(node.tokens) == 4)
-        self.assertTrue(isinstance(node.tokens[0], preprocessor.Identifier))
-        self.assertTrue(node.tokens[0].token == "defined")
+        self.assertTrue(len(node.tokens) == 3)
+        self.assertTrue(len(node.expr) == 4)
+        self.assertTrue(isinstance(node.expr[0], preprocessor.Identifier))
+        self.assertTrue(node.expr[0].token == "defined")
 
     def test_ifndef(self):
         """ifndef"""
         tokens = preprocessor.Lexer("#ifndef FOO").tokenize()
         node = preprocessor.DirectiveParser(tokens).parse()
         self.assertTrue(isinstance(node, preprocessor.IfNode))
-        self.assertTrue(len(node.tokens) == 5)
-        self.assertTrue(isinstance(node.tokens[0], preprocessor.Operator))
-        self.assertTrue(node.tokens[0].token == "!")
-        self.assertTrue(isinstance(node.tokens[1], preprocessor.Identifier))
-        self.assertTrue(node.tokens[1].token == "defined")
+        self.assertTrue(len(node.tokens) == 3)
+        self.assertTrue(len(node.expr) == 5)
+        self.assertTrue(isinstance(node.expr[0], preprocessor.Operator))
+        self.assertTrue(node.expr[0].token == "!")
+        self.assertTrue(isinstance(node.expr[1], preprocessor.Identifier))
+        self.assertTrue(node.expr[1].token == "defined")
 
     def test_elif(self):
         """elif"""
         tokens = preprocessor.Lexer("#elif FOO == BAR").tokenize()
         node = preprocessor.DirectiveParser(tokens).parse()
         self.assertTrue(isinstance(node, preprocessor.ElIfNode))
-        self.assertTrue(len(node.tokens) == 3)
+        self.assertTrue(len(node.tokens) == 5)
+        self.assertTrue(len(node.expr) == 3)
 
     def test_else(self):
         """else"""


### PR DESCRIPTION
# Related issues

Part of #36, similar to #143.

# Proposed changes

- Ensure that classes derived from `DirectiveNode` set `tokens` during initialization. The goal here was to simplify the process of converting things to data classes, because things can get complicated very quickly when the class hierarchy isn't obeyed.
- Make some minor adjustments to some `DirectiveNode` tests, because there was some inconsistency there: some derived classes used `tokens` to store a subset of tokens that were deemed relevant (e.g., the expression following a `#define`) when they should have been storing all tokens that make up the directive (i.e, including `#` and the directive name).
- Replace node-specific `spelling()` functions with a common function that prints all the `tokens`.
- Remove the `kind` field from `DirectiveNode` and its derived classes, because it wasn't used for anything.
- Remove the `file_hash` field from `FileNode`, because it was only used for the `__repr__` string.
- Convert `Node`, `CodeNode`, `DirectiveNode`, and all derived classes into data classes, removing `__init__` and `__repr__` appropriately.

---

I think the `@dataclass` design here is cleaner than what we had before, but it does highlight that `CodeNode` is a bit broken.  Ideally we would derive the value for fields like `num_lines` from the tokens passed to the initialization of derived classes, but this doesn't work.  Because we handle line continuations before lexing, directives that span multiple lines set the wrong `line` field for constituent tokens. We should aim to fix this as part of #102.

Note also that all the `Node` classes use `@dataclass(eq=False)`.  This is currently necessary because the associator code currently stores a mapping from nodes to platforms, which requires that `Node` classes are hashable.