### PR TITLE
Fix use of ensure_ext in coverage

### DIFF
--- a/codebasin/coverage/__main__.py
+++ b/codebasin/coverage/__main__.py
@@ -113,8 +113,7 @@ def _compute(args: argparse.Namespace):
     for path in [dbpath, covpath]:
         if not util.valid_path(path):
             raise ValueError(f"{path} is not a valid path.")
-        if not util.ensure_ext(path, [".json"]):
-            raise ValueError(f"{path} is not a JSON file.")
+        util.ensure_ext(path, [".json"])
 
     source_dir = os.path.realpath(args.source_dir)
 


### PR DESCRIPTION
Checking the return type of `ensure_ext` is no longer valid after we changed its behavior.

# Related issues

This was broken in #41, but changes in #141 weren't caught due to #129.

# Proposed changes

- Update usage of `ensure_ext` to align with changes from #141.