### PR TITLE
Rename cbicov to cbi-cov

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,7 +37,7 @@ dependencies = [
 
 [project.scripts]
 codebasin = "codebasin:__main__.main"
-cbicov = "codebasin.coverage:__main__.main"
+cbi-cov = "codebasin.coverage:__main__.main"
 
 [project.urls]
 "Github" = "https://www.github.com/intel/code-base-investigator"

--- a/tests/cli/test_cbicov.py
+++ b/tests/cli/test_cbicov.py
@@ -14,9 +14,9 @@ from pathlib import Path
 from codebasin.coverage.__main__ import cli
 
 
-class TestCbicov(unittest.TestCase):
+class TestCbiCov(unittest.TestCase):
     """
-    Test cbicov command line interface.
+    Test cbi-cov command line interface.
     """
 
     def setUp(self):
@@ -78,7 +78,7 @@ class TestCbicov(unittest.TestCase):
         with open(p / "bar.h", mode="w") as f:
             f.write("unguarded();")
 
-        # cbicov reads compile commands from disk.
+        # cbi-cov reads compile commands from disk.
         compile_commands = [
             {
                 "file": str(p / "foo.cpp"),


### PR DESCRIPTION
Although this may seem like an insignificant change, it is aligned with the naming convention of other tools (e.g., clang-tidy, llvm-cov) and makes it easier for a reader to separate "cbi" from the name of the tool.

# Related issues

Part of #152. 

# Proposed changes

- Rename `cbicov` script to `cbi-cov`.
- Replace occurrences of cbicov with cbi-cov in tests.
