### PR TITLE
Add coverage workflow to GitHub Actions

### DIFF
--- a/.github/workflows/check-coverage.py
+++ b/.github/workflows/check-coverage.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import subprocess  # nosec B404
+import sys
+
+# Parse command-line arguments.
+parser = argparse.ArgumentParser()
+parser.add_argument("--commits", nargs="+", default=[])
+parser.add_argument("file", metavar="<coverage.json>", action="store")
+args = parser.parse_args(sys.argv[1:])
+
+# Read the coverage information into an object.
+with open(args.file, "rb") as f:
+    coverage = json.load(f)
+
+# For each file:
+# - Determine which lines were not covered;
+# - Check when the lines were last modified;
+# - Print details of new, uncovered, lines.
+report = {}
+for filename, info in coverage["files"].items():
+    if not isinstance(filename, str):
+        raise TypeError("filename must be a string")
+
+    missing = info["missing_lines"]
+    if not missing:
+        continue
+
+    for lineno in missing:
+        if not isinstance(lineno, int):
+            raise TypeError("line numbers must be integers")
+        cmd = [
+            "git",
+            "blame",
+            filename,
+            "-L",
+            f"{lineno},{lineno}",
+            "--no-abbrev",
+        ]
+        completed = subprocess.run(cmd, capture_output=True)
+        commit = completed.stdout.decode().split()[0].strip()
+
+        if commit in args.commits:
+            if filename not in report:
+                report[filename] = []
+            report[filename].append(str(lineno))
+
+for filename in report:
+    n = len(report[filename])
+    print(f'{n} uncovered lines in {filename}: {",".join(report[filename])}')
+
+# Use the exit code to communicate failure to GitHub.
+if len(report) != 0:
+    sys.exit(1)
+else:
+    sys.exit(0)

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,49 @@
+name: coverage
+
+permissions: read-all
+
+on:
+  pull_request:
+    branches: [ "main" ]
+    paths:
+      - 'codebasin/**'
+
+jobs:
+  check-coverage:
+    name: Ensure modified lines are tested
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ["3.12"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install `code-base-investigator`
+        run: |
+          python -m pip install -U pip
+          pip install .
+
+      - name: Install `coverage`
+        run: |
+          pip install coverage
+
+      - name: Run `coverage`
+        run: |
+          python -m coverage run -m unittest
+
+      - name: Generate coverage.json
+        run: |
+          python -m coverage json --include=$(git diff --name-status main codebasin/*.py | grep "^M" | awk '{ print $2 }' | paste -sd,)
+
+      - name: Check coverage against latest commits
+        run: |
+          FROM=${{ github.event.pull_request.base.sha }}
+          TO=${{ github.event.pull_request.head.sha }}
+          COMMITS=$(git rev-list $FROM..$TO)
+          python .github/workflows/check-coverage.py coverage.json --commits $COMMITS


### PR DESCRIPTION
This action performs a coverage analysis for any source files that have been modified, and reports if there are any new or modified lines that are not covered by any tests.

The coverage analysis is focused on new code because we know there are paths that are currently not covered; the intent of this new action is only to prevent a pull request from making the situation worse.

# Related issues

Closes #47. 🎉  

# Proposed changes

- Add a new GitHub action to check coverage.
- Add `check-coverage.py` to:
  - Read a coverage.json file;
  - Parse the `git blame` information for each missing line; and
  - Report any lines where `blame` points to a commit SHA that was passed to the script via its `--commits` argument.
- Add `coverage.yml` to:
  - Run `coverage`;
  - Generate coverage.json for only the files that were modified by the PR; and
  - Run `check-coverage.py` on coverage.json.
