### PR TITLE
Add custom argparse actions

### DIFF
--- a/codebasin/config.py
+++ b/codebasin/config.py
@@ -100,12 +100,24 @@ class _StoreSplitAction(argparse.Action):
     separator, then stores the resulting list.
     """
 
-    def __init__(self, option_strings, dest, nargs=None, **kwargs):
+    def __init__(
+        self,
+        option_strings: list[str],
+        dest: str,
+        nargs=None,
+        **kwargs,
+    ):
         self.sep = kwargs.pop("sep", None)
         self.format = kwargs.pop("format", None)
         super().__init__(option_strings, dest, nargs=nargs, **kwargs)
 
-    def __call__(self, parser, namespace, values, option_string):
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        values: str,
+        option_string: str,
+    ):
         if not isinstance(values, str):
             raise TypeError("store_split expects string values")
         split_values = values.split(self.sep)
@@ -125,12 +137,24 @@ class _ExtendMatchAction(argparse.Action):
     pattern, then extends the destination list using the result(s).
     """
 
-    def __init__(self, option_strings, dest, nargs=None, **kwargs):
+    def __init__(
+        self,
+        option_strings: list[str],
+        dest: str,
+        nargs=None,
+        **kwargs,
+    ):
         self.pattern = kwargs.pop("pattern", None)
         self.format = kwargs.pop("format", None)
         super().__init__(option_strings, dest, nargs=nargs, **kwargs)
 
-    def __call__(self, parser, namespace, value, option_string):
+    def __call__(
+        self,
+        parser: argparse.ArgumentParser,
+        namespace: argparse.Namespace,
+        value: str,
+        option_string: str,
+    ):
         if not isinstance(value, str):
             raise TypeError("extend_match expects string value")
         matches = re.findall(self.pattern, value)

--- a/tests/compilers/test_actions.py
+++ b/tests/compilers/test_actions.py
@@ -1,0 +1,65 @@
+# Copyright (C) 2019-2024 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+
+import argparse
+import logging
+import unittest
+
+from codebasin.config import _StoreSplitAction
+
+
+class TestActions(unittest.TestCase):
+    """
+    Test that custom argparse.Action classes work as expected.
+    These classes enable handling of complex user-defined compiler options.
+    """
+
+    def setUp(self):
+        logging.disable()
+
+    def test_store_split_init(self):
+        """Check that store_split recognizes custom arguments"""
+        action = _StoreSplitAction(["--foo"], "foo", sep=",", format="$value")
+        self.assertEqual(action.sep, ",")
+        self.assertEqual(action.format, "$value")
+
+        action = _StoreSplitAction(["--foo"], "foo")
+        self.assertEqual(action.sep, None)
+        self.assertEqual(action.format, None)
+
+    def test_store_split(self):
+        """Check that argparse calls store_split correctly"""
+        namespace = argparse.Namespace()
+        namespace.passes = {}
+
+        parser = argparse.ArgumentParser()
+        parser.add_argument("--foo", action=_StoreSplitAction, sep=",")
+        parser.add_argument(
+            "--bar",
+            action=_StoreSplitAction,
+            sep=",",
+            format="prefix-$value-suffix",
+        )
+        parser.add_argument("--baz", action=_StoreSplitAction, type=int)
+        parser.add_argument(
+            "--qux",
+            action=_StoreSplitAction,
+            sep=",",
+            dest="passes",
+        )
+
+        args, _ = parser.parse_known_args(["--foo=one,two"], namespace)
+        self.assertEqual(args.foo, ["one", "two"])
+
+        args, _ = parser.parse_known_args(["--bar=one,two"], namespace)
+        self.assertEqual(args.bar, ["prefix-one-suffix", "prefix-two-suffix"])
+
+        with self.assertRaises(TypeError):
+            args, _ = parser.parse_known_args(["--baz=1"], namespace)
+
+        args, _ = parser.parse_known_args(["--qux=one,two"], namespace)
+        self.assertEqual(args.passes, {"--qux": ["one", "two"]})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Related issues

- Part of #145; these two actions are required to configure `argparse` such that its behavior is equivalent to the custom argument handling code introduced in CBI 1.2.0.

# Proposed changes

- Add `_StoreSplitAction` to handle comma-delimited arguments (e.g., `-fsycl-targets=t1,t2`).
- Add `_ExtendMatchAction` to handle arguments requiring regular expressions (e.g., `--gencode=sm_70,compute_75`).
- Add tests for both new actions.

---

Recognizing custom compiler arguments is a big feature, so I'm going to try and split it out into bite-sized chunks for review.