### PR TITLE
Add compiler customization schema

### DIFF
--- a/codebasin/schema/cbiconfig.schema
+++ b/codebasin/schema/cbiconfig.schema
@@ -9,16 +9,135 @@
       "type": "object",
       "patternProperties": {
         ".*": {
-          "type": "object",
-          "properties": {
-            "options": {
-              "type": "array",
-              "items": {
-                "type": "string"
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "options": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                }
+              },
+                "parser": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "flags": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "action": {
+                      "type": "string"
+                    },
+                    "dest": {
+                      "type": "string"
+                    },
+                    "const": {
+                      "type": "string"
+                    },
+                    "sep": {
+                      "type": "string"
+                    },
+                    "format": {
+                      "type": "string"
+                    },
+                    "pattern": {
+                      "type": "string"
+                    },
+                    "default": {
+                      "oneOf": [
+                        {
+                          "type": "string"
+                        },
+                        {
+                          "type": "array",
+                          "items": {
+                            "type": "string"
+                          }
+                        }
+                      ]
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+                "modes": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "defines": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "include_paths": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "include_files": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "additionalProperties": false
+                }
+              },
+                "passes": {
+                "type": "array",
+                "items": {
+                  "type": "object",
+                  "properties": {
+                    "name": {
+                      "type": "string"
+                    },
+                    "defines": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "include_paths": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "include_files": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "additionalProperties": false
+                }
               }
+              },
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "alias_of": {
+                  "type": "string"
+                }
+              },
+              "additionalProperties": false
             }
-          },
-          "additionalProperties": false
+          ]
         }
       }
     },

--- a/codebasin/schema/cbiconfig.schema
+++ b/codebasin/schema/cbiconfig.schema
@@ -60,6 +60,9 @@
                           }
                         }
                       ]
+                    },
+                    "override": {
+                        "type": "boolean"
                     }
                   },
                   "additionalProperties": false

--- a/codebasin/schema/cbiconfig.schema
+++ b/codebasin/schema/cbiconfig.schema
@@ -124,6 +124,12 @@
                       "items": {
                         "type": "string"
                       }
+                    },
+                    "modes": {
+                      "type": "array",
+                      "items": {
+                        "type": "string"
+                      }
                     }
                   },
                   "required": ["name"],

--- a/codebasin/schema/cbiconfig.schema
+++ b/codebasin/schema/cbiconfig.schema
@@ -92,6 +92,7 @@
                       }
                     }
                   },
+                  "required": ["name"],
                   "additionalProperties": false
                 }
               },
@@ -122,6 +123,7 @@
                       }
                     }
                   },
+                  "required": ["name"],
                   "additionalProperties": false
                 }
               }

--- a/tests/schema/test_schema.py
+++ b/tests/schema/test_schema.py
@@ -184,6 +184,7 @@ class TestSchema(unittest.TestCase):
             defines = ["DEVICE"]
             include_paths = ["/device/"]
             include_files = ["device.inc"]
+            modes = ["device-mode"]
         """,
         )
 

--- a/tests/schema/test_schema.py
+++ b/tests/schema/test_schema.py
@@ -121,6 +121,7 @@ class TestSchema(unittest.TestCase):
             dest = "passes"
             pattern = "*"
             format = "$value"
+            override = true
         """,
         )
 

--- a/tests/schema/test_schema.py
+++ b/tests/schema/test_schema.py
@@ -178,7 +178,7 @@ class TestSchema(unittest.TestCase):
             include_paths = ["/host/"]
             include_files = ["host.inc"]
 
-            [[compiler.test.modes]]
+            [[compiler.test.passes]]
             name = "device"
             defines = ["DEVICE"]
             include_paths = ["/device/"]

--- a/tests/schema/test_schema.py
+++ b/tests/schema/test_schema.py
@@ -150,11 +150,21 @@ class TestSchema(unittest.TestCase):
         """,
         )
 
+        # A compiler mode must have a name.
+        with self.assertRaises(ValueError):
+            _test_toml_string(
+                """
+                [[compiler.test.modes]]
+                defines = ["LANGUAGE"]
+            """,
+            )
+
         # A compiler cannot define any other mode keys.
         with self.assertRaises(ValueError):
             _test_toml_string(
                 """
                 [[compiler.test.modes]]
+                name = "required"
                 additional = "True"
             """,
             )
@@ -176,11 +186,21 @@ class TestSchema(unittest.TestCase):
         """,
         )
 
+        # A compiler pass must have a name.
+        with self.assertRaises(ValueError):
+            _test_toml_string(
+                """
+                [[compiler.test.passes]]
+                defines = ["LANGUAGE"]
+            """,
+            )
+
         # A compiler cannot define any other pass keys.
         with self.assertRaises(ValueError):
             _test_toml_string(
                 """
                 [[compiler.test.passes]]
+                name = "required"
                 additional = "True"
             """,
             )

--- a/tests/schema/test_schema.py
+++ b/tests/schema/test_schema.py
@@ -2,10 +2,19 @@
 # SPDX-License-Identifier: BSD-3-Clause
 
 import logging
+import tempfile
 import unittest
 
 import codebasin.config as config
 import codebasin.util as util
+
+
+def _test_toml_string(contents: str):
+    f = tempfile.NamedTemporaryFile(suffix=".toml")
+    f.write(contents.encode())
+    f.seek(0)
+    _ = util._load_toml(f, "cbiconfig")
+    f.close()
 
 
 class TestSchema(unittest.TestCase):
@@ -44,6 +53,137 @@ class TestSchema(unittest.TestCase):
         with open(path, "rb") as f:
             with self.assertRaises(ValueError):
                 toml = util._load_toml(f, "cbiconfig")
+
+    def test_cbiconfig_compilers(self):
+        """Check validation of compiler customization"""
+
+        # Compilers can be aliases of other compilers.
+        _test_toml_string(
+            """
+            [compiler.test]
+            alias_of = "icc"
+        """,
+        )
+
+        # Compilers can have options.
+        _test_toml_string(
+            """
+            [compiler.test]
+            options = ["-D", "ASDF"]
+        """,
+        )
+
+        # A compiler alias cannot have options.
+        with self.assertRaises(ValueError):
+            _test_toml_string(
+                """
+                [compiler.test]
+                alias_of = "icc"
+                options = ["-D", "ASDF"]
+            """,
+            )
+
+        # A compiler cannot define any other keys.
+        with self.assertRaises(ValueError):
+            _test_toml_string(
+                """
+                [compiler.test]
+                additional = "True"
+            """,
+            )
+
+        # A compiler can define multiple parser options.
+        _test_toml_string(
+            """
+            [[compiler.test.parser]]
+            action = "store_const"
+            dest = "defines"
+            const = "ASDF"
+
+            [[compiler.test.parser]]
+            action = "store"
+            dest = "defines"
+            default = "one-value"
+
+            [[compiler.test.parser]]
+            action = "append"
+            dest = "defines"
+            default = ["multiple", "values"]
+
+            [[compiler.test.parser]]
+            action = "store_split"
+            dest = "passes"
+            sep = ","
+            format = "$value"
+
+            [[compiler.test.parser]]
+            action = "extend_match"
+            dest = "passes"
+            pattern = "*"
+            format = "$value"
+        """,
+        )
+
+        # A compiler cannot define any other parser keys.
+        with self.assertRaises(ValueError):
+            _test_toml_string(
+                """
+                [[compiler.test.parser]]
+                additional = "True"
+            """,
+            )
+
+        # A compiler can define multiple modes.
+        _test_toml_string(
+            """
+            [[compiler.test.modes]]
+            name = "language"
+            defines = ["LANGUAGE"]
+            include_paths = ["/language/"]
+            include_files = ["language.inc"]
+
+            [[compiler.test.modes]]
+            name = "another-language"
+            defines = ["ANOTHER_LANGUAGE"]
+            include_paths = ["/another-language/"]
+            include_files = ["another_language.inc"]
+        """,
+        )
+
+        # A compiler cannot define any other mode keys.
+        with self.assertRaises(ValueError):
+            _test_toml_string(
+                """
+                [[compiler.test.modes]]
+                additional = "True"
+            """,
+            )
+
+        # A compiler can define multiple passes.
+        _test_toml_string(
+            """
+            [[compiler.test.passes]]
+            name = "host"
+            defines = ["HOST"]
+            include_paths = ["/host/"]
+            include_files = ["host.inc"]
+
+            [[compiler.test.modes]]
+            name = "device"
+            defines = ["DEVICE"]
+            include_paths = ["/device/"]
+            include_files = ["device.inc"]
+        """,
+        )
+
+        # A compiler cannot define any other pass keys.
+        with self.assertRaises(ValueError):
+            _test_toml_string(
+                """
+                [[compiler.test.passes]]
+                additional = "True"
+            """,
+            )
 
     def test_analysis_file(self):
         """schema/analysis_file"""


### PR DESCRIPTION
# Related issues

- Part of https://github.com/intel/code-base-investigator/issues/145; the modified schema allows a configuration file to define  custom implicit compiler behavior (i.e., macro definitions, include paths and include files) based on compiler arguments.

# Proposed changes

- Extend the schema to support:
  - `alias_of`: Defines that a compiler is an alias of another (e.g., `icpx` is an alias of `icx`)
  - `[[compiler."compiler name".parser]]`: A table of arguments for `argparse`.
  - `[[compiler."compiler name".modes]]`: A table of "modes", each of which is a collection of compiler behaviors that can later be enabled by a flag (e.g., `-fopenmp` enables the "openmp" mode, which in turn defines `_OPENMP`, etc).
  - `[[compiler."compiler name".passes]]`: A table of "passes", each of which is a collection of compiler behaviors associated with a separate pass over a source file (e.g., `-fsycl-targets=spir64,nvidia-ptx-cuda` will compile the source file to SPIR-V and PTX, with different macros defined).
- Add new tests for the proposed schema.

---

I appreciate that JSON schema can be really difficult to read, so I've tried extra hard to improve the readability of the tests here.  Each call to `_test_toml_string` without an `assertRaises` demonstrates the syntax of a valid use-case.  Each call with an `assertRaises` is intended to test either a `oneOf`, `additionalProperties` or `required` clause in the schema.