### PR TITLE
Add instructions for virtual environments

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,7 +19,7 @@ release = "1.2.0"
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 
-extensions = ["sphinx.ext.mathjax"]
+extensions = ["sphinx.ext.mathjax", "sphinx_inline_tabs"]
 
 templates_path = ["_templates"]
 exclude_patterns = []

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -66,10 +66,27 @@ release, run the following::
     $ cd code-base-investigator
     $ pip install .
 
-We strongly recommend installing CBI within a `virtual environment`_.
+We strongly recommend installing CBI within a virtual environment, to simplify
+dependency management and improve security. Some alternative methods of
+creating a virtual environment are shown below.
 
-.. _`virtual environment`: https://docs.python.org/3/library/venv.html
+.. tab:: venv
 
+    .. code-block:: text
+
+        $ git clone --branch 1.2.0 https://github.com/intel/code-base-investigator.git
+        $ python3 -m venv cbi
+        $ source cbi/bin/activate
+        $ cd code-base-investigator
+        $ pip install .
+
+.. tab:: uv
+
+    .. code-block:: text
+
+        $ git clone --branch 1.2.0 https://github.com/intel/code-base-investigator.git
+        $ cd code-base-investigator
+        $ uv tool install .
 
 Getting Started
 ###############


### PR DESCRIPTION
Previously, we just linked to the documentation for "virtual environments".

Users have several options for creating these, and providing configuration commands that can be copied-and-pasted into a terminal may improve the out-of-box experience.

The changes in this commit add instructions for venv and uv. Each option is displayed as a separate tab, so it should be straightforward to add more options in the future.

# Related issues

Closes #151. 

# Proposed changes

- Add `sphinx_inline_tabs` extension to the documentation, to enable tabbed code blocks.
- Explain why we recommend virtual environments.
- Use a tabbed block to show how to set up a virtual environment with `venv` and `uv`.