### PR TITLE
Add test of summary report

### DIFF
--- a/tests/report/test_summary_report.py
+++ b/tests/report/test_summary_report.py
@@ -1,0 +1,52 @@
+# Copyright (C) 2019-2024 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+
+import logging
+import unittest
+from io import StringIO
+
+from codebasin.report import summary
+
+
+class TestSummaryReport(unittest.TestCase):
+    """
+    Test summary report functionality.
+    """
+
+    def setUp(self):
+        logging.disable()
+
+    def test_output(self):
+        """Check summary report output"""
+        setmap = {
+            frozenset(["X"]): 1,
+            frozenset(["Y"]): 2,
+            frozenset(["X", "Y"]): 3,
+            frozenset([]): 6,
+        }
+        output = StringIO()
+        summary(setmap, stream=output)
+        expected = """
+Summary
+=======
+┌────────────────┬───────┬─────────┐
+│   Platform Set │   LOC │   % LOC │
+├────────────────┼───────┼─────────┤
+│             {} │     6 │   50.00 │
+├────────────────┼───────┼─────────┤
+│            {X} │     1 │    8.33 │
+├────────────────┼───────┼─────────┤
+│            {Y} │     2 │   16.67 │
+├────────────────┼───────┼─────────┤
+│         {X, Y} │     3 │   25.00 │
+└────────────────┴───────┴─────────┘
+Code Divergence: 0.50
+Code Utilization: 0.38
+Unused Code (%): 50.00
+Total SLOC: 12
+"""
+        self.assertEqual(expected, output.getvalue())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Related issues

- #36  
- #96 

# Proposed changes

- Add a simple test for the summary report.

---

As part of #149, we want to change the way that "Unused code" is presented.  The new workflow in #154 requires that the summary report is covered by a test before we're allowed to change it -- so it's working as intended! 🥳 
