### PR TITLE
Attempt to fix non-deterministic tests

### DIFF
--- a/tests/cli/test_cbicov.py
+++ b/tests/cli/test_cbicov.py
@@ -7,7 +7,6 @@ import logging
 import sys
 import tempfile
 import unittest
-import warnings
 from contextlib import redirect_stdout
 from pathlib import Path
 
@@ -21,7 +20,6 @@ class TestCbiCov(unittest.TestCase):
 
     def setUp(self):
         logging.disable()
-        warnings.simplefilter("ignore", ResourceWarning)
 
     def test_help(self):
         """Check help string displays correctly."""
@@ -66,8 +64,8 @@ class TestCbiCov(unittest.TestCase):
         """Check that coverage is computed correctly."""
         sys.stdout = io.StringIO()
         # Create a temporary codebase to work on.
-        self.tmp = tempfile.TemporaryDirectory()
-        p = Path(self.tmp.name)
+        tmp = tempfile.TemporaryDirectory()
+        p = Path(tmp.name)
         with open(p / "foo.cpp", mode="w") as f:
             f.write(
                 r"""#ifdef MACRO
@@ -109,6 +107,8 @@ class TestCbiCov(unittest.TestCase):
         ]
         self.assertEqual(coverage, expected_coverage)
         sys.stdout = sys.__stdout__
+
+        tmp.cleanup()
 
 
 if __name__ == "__main__":

--- a/tests/cli/test_cbicov.py
+++ b/tests/cli/test_cbicov.py
@@ -105,7 +105,7 @@ class TestCbiCov(unittest.TestCase):
                 "lines": [1, 3, 4],
             },
         ]
-        self.assertEqual(coverage, expected_coverage)
+        self.assertCountEqual(coverage, expected_coverage)
         sys.stdout = sys.__stdout__
 
         tmp.cleanup()

--- a/tests/code-base/test_code_base.py
+++ b/tests/code-base/test_code_base.py
@@ -4,7 +4,6 @@
 import logging
 import tempfile
 import unittest
-import warnings
 from pathlib import Path
 
 from codebasin import CodeBase
@@ -17,7 +16,6 @@ class TestCodeBase(unittest.TestCase):
 
     def setUp(self):
         logging.disable()
-        warnings.simplefilter("ignore", ResourceWarning)
 
         # Create a temporary codebase spread across two directories
         self.tmp1 = tempfile.TemporaryDirectory()

--- a/tests/code-base/test_code_base.py
+++ b/tests/code-base/test_code_base.py
@@ -14,7 +14,8 @@ class TestCodeBase(unittest.TestCase):
     Test CodeBase class.
     """
 
-    def setUp(self):
+    @classmethod
+    def setUpClass(self):
         logging.disable()
 
         # Create a temporary codebase spread across two directories
@@ -29,6 +30,11 @@ class TestCodeBase(unittest.TestCase):
         open(p2 / "qux.cpp", mode="w").close()
         open(p2 / "quux.h", mode="w").close()
         open(p2 / "README.md", mode="w").close()
+
+    @classmethod
+    def tearDownClass(self):
+        self.tmp1.cleanup()
+        self.tmp2.cleanup()
 
     def test_constructor(self):
         """Check directories and exclude_patterns are handled correctly"""

--- a/tests/duplicates/test_duplicates.py
+++ b/tests/duplicates/test_duplicates.py
@@ -118,6 +118,8 @@ class TestDuplicates(unittest.TestCase):
         setmap = state.get_setmap(codebase)
         self.assertDictEqual(setmap, expected_setmap, "Mismatch in setmap")
 
+        tmp.cleanup()
+
     def test_find_duplicates(self):
         """Check that we can correctly identify duplicate files."""
         tmp = tempfile.TemporaryDirectory()

--- a/tests/files/test_filetree.py
+++ b/tests/files/test_filetree.py
@@ -5,7 +5,6 @@ import logging
 import os
 import tempfile
 import unittest
-import warnings
 from pathlib import Path
 
 from codebasin.report import FileTree
@@ -18,7 +17,6 @@ class TestFileTree(unittest.TestCase):
 
     def setUp(self):
         logging.disable()
-        warnings.simplefilter("ignore", ResourceWarning)
 
         self.setmap = {
             frozenset(["X"]): 1,

--- a/tests/files/test_filetree.py
+++ b/tests/files/test_filetree.py
@@ -15,7 +15,8 @@ class TestFileTree(unittest.TestCase):
     Test FileTree functionality.
     """
 
-    def setUp(self):
+    @classmethod
+    def setUpClass(self):
         logging.disable()
 
         self.setmap = {
@@ -30,6 +31,10 @@ class TestFileTree(unittest.TestCase):
         open(self.path / "file.cpp", mode="w").close()
         open(self.path / "other.cpp", mode="w").close()
         os.symlink(self.path / "file.cpp", self.path / "symlink.cpp")
+
+    @classmethod
+    def tearDownClass(self):
+        self.tmp.cleanup()
 
     def test_constructor(self):
         """Check FileTree constructor."""

--- a/tests/files/test_filetree_node.py
+++ b/tests/files/test_filetree_node.py
@@ -16,7 +16,8 @@ class TestFileTreeNode(unittest.TestCase):
     Test FileTree.Node functionality.
     """
 
-    def setUp(self):
+    @classmethod
+    def setUpClass(self):
         logging.disable()
 
         self.setmap = {
@@ -30,6 +31,10 @@ class TestFileTreeNode(unittest.TestCase):
         self.path = Path(self.tmp.name)
         open(self.path / "file.cpp", mode="w").close()
         os.symlink(self.path / "file.cpp", self.path / "symlink.cpp")
+
+    @classmethod
+    def tearDownClass(self):
+        self.tmp.cleanup()
 
     def test_constructor(self):
         """Check FileTree.Node constructor."""

--- a/tests/files/test_filetree_node.py
+++ b/tests/files/test_filetree_node.py
@@ -5,7 +5,6 @@ import logging
 import os
 import tempfile
 import unittest
-import warnings
 from collections import defaultdict
 from pathlib import Path
 
@@ -19,7 +18,6 @@ class TestFileTreeNode(unittest.TestCase):
 
     def setUp(self):
         logging.disable()
-        warnings.simplefilter("ignore", ResourceWarning)
 
         self.setmap = {
             frozenset(["X"]): 1,

--- a/tests/metrics/test_divergence.py
+++ b/tests/metrics/test_divergence.py
@@ -4,7 +4,6 @@
 import logging
 import math
 import unittest
-import warnings
 
 from codebasin.report import divergence
 
@@ -16,7 +15,6 @@ class TestDivergence(unittest.TestCase):
 
     def setUp(self):
         logging.disable()
-        warnings.simplefilter("ignore", ResourceWarning)
 
     def test_divergence(self):
         """Check divergence computation for simple setmap."""

--- a/tests/metrics/test_utilization.py
+++ b/tests/metrics/test_utilization.py
@@ -4,7 +4,6 @@
 import logging
 import math
 import unittest
-import warnings
 
 from codebasin.report import normalized_utilization, utilization
 
@@ -16,7 +15,6 @@ class TestUtilization(unittest.TestCase):
 
     def setUp(self):
         logging.disable()
-        warnings.simplefilter("ignore", ResourceWarning)
 
     def test_utilization(self):
         """Check utilization computation for simple setmap."""

--- a/tests/source-tree/test_source_tree.py
+++ b/tests/source-tree/test_source_tree.py
@@ -4,7 +4,6 @@
 import logging
 import tempfile
 import unittest
-import warnings
 
 from codebasin.file_parser import FileParser
 from codebasin.preprocessor import CodeNode, DirectiveNode, FileNode, Visit
@@ -17,7 +16,6 @@ class TestSourceTree(unittest.TestCase):
 
     def setUp(self):
         logging.getLogger("codebasin").disabled = False
-        warnings.simplefilter("ignore", ResourceWarning)
 
         # TODO: Revisit this when SourceTree can be built without a file.
         with tempfile.NamedTemporaryFile(


### PR DESCRIPTION
# Related issues

- #159 

# Proposed changes

- Fix a weird-looking assignment to `self.tmp` inside of the cbi-cov tests.
- Remove `ResourceWarning` filters from _all_ tests, so we can't ignore them.
- Add explicit calls to `cleanup()` when we're finished with a `TemporaryDirectory`.
- Use `setUpClass` and `tearDownClass` in cases where all tests can share the same resources.
- Use `assertCountEqual` instead of `assertEqual` when comparing `coverage.json` files.

---

Even the old tests worked deterministically on my laptop, so I have no idea if this will actually fix anything.  But the changes make sense to me, so 🤞. 

**EDIT**: I suspect the `assertCountEqual` change here is the real fix, but I think we should merge the `TemporaryDirectory` changes as well.  Even if they weren't the cause of the non-determinism in #159, the new versions of the tests are cleaner.
