### PR TITLE
Fix coverage action

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -44,6 +44,6 @@ jobs:
       - name: Check coverage against latest commits
         run: |
           FROM=${{ github.event.pull_request.base.sha }}
-          TO=${{ github.event.pull_request.head.sha }}
+          TO=${{ github.sha }}
           COMMITS=$(git rev-list $FROM..$TO)
           python .github/workflows/check-coverage.py coverage.json --commits $COMMITS

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -39,7 +39,7 @@ jobs:
 
       - name: Generate coverage.json
         run: |
-          python -m coverage json --include=$(git diff --name-status main codebasin/*.py | grep "^M" | awk '{ print $2 }' | paste -sd,)
+          python -m coverage json --include=$(git diff --name-status ${{ github.event.pull_request.base.sha }} codebasin/*.py | grep "^M" | awk '{ print $2 }' | paste -sd,)
 
       - name: Check coverage against latest commits
         run: |


### PR DESCRIPTION
# Related issues

N/A

# Proposed changes

- Consistently use `${{ github.event.pull_request.base.sha }}` instead of "main".
- Use the merge commit created by GitHub (`${{ github.sha }}`) instead of the original head commit (`${{ github.event.pull_request.head.sha }}`) as the latest commit.
