### PR TITLE
Force coverage.yml to check out all commits

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -18,6 +18,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4


### PR DESCRIPTION
# Related issues

N/A

# Proposed changes

- Set `fetch-depth` to 0 to force `checkout` to grab all the commits.
