### PR TITLE
Fix bug in FileTree's handling of unused files 

### DIFF
--- a/codebasin/report.py
+++ b/codebasin/report.py
@@ -780,9 +780,12 @@ def files(
     for f in codebase:
         setmap = defaultdict(int)
         if state:
-            for node, assoc in state.get_map(f).items():
-                if isinstance(node, CodeNode):
-                    setmap[frozenset(assoc)] += node.num_lines
+            association = state.get_map(f)
+            for node in [
+                n for n in state.get_tree(f).walk() if isinstance(n, CodeNode)
+            ]:
+                platform = frozenset(association[node])
+                setmap[platform] += node.num_lines
         tree.insert(f, setmap)
 
     print("", file=stream)

--- a/codebasin/report.py
+++ b/codebasin/report.py
@@ -781,9 +781,10 @@ def files(
         setmap = defaultdict(int)
         if state:
             association = state.get_map(f)
-            for node in [
-                n for n in state.get_tree(f).walk() if isinstance(n, CodeNode)
-            ]:
+            for node in filter(
+                lambda x: isinstance(x, CodeNode),
+                state.get_tree(f).walk(),
+            ):
                 platform = frozenset(association[node])
                 setmap[platform] += node.num_lines
         tree.insert(f, setmap)


### PR DESCRIPTION
# Related issues

N/A

# Proposed changes

- Add a regression test that checks unused files contribute to the statistics of their parent directories.
- Fix the construction of the `setmap` that is used within each `FileTree` node.

---

The issue with the original code is pretty subtle, so I'll try and explain it here.

By constructing a `setmap` based on the association map, we were implicitly only looking at code that had been touched by one platform (because unused code is not entered into the association map).  Unused files were being correctly tagged as unused (because there no platforms in the `setmap`), but the unused lines themselves were not propagating upwards (because the `setmap` did not contain an entry for the empty set, `frozenset([])`).

The fix is to construct the `setmap` by walking the specialization tree instead, so that we encounter all `CodeNode`s in a file (including the ones that are unused).

Note that we cannot simply call the `get_setmap()` function from `ParserState`, because that returns a single `setmap` for the entire code base, and has its own handling for things like symlinks.  The longer term fix for this mess is to actually do something with #135, because `setmap` handling throughout the code is pretty janky and inconsistent.  Having a dedicated object would allow us to check that some basic conditions always hold.