### PR TITLE
Expose tree report as standalone cbi-tree utility

### DIFF
--- a/codebasin/__main__.py
+++ b/codebasin/__main__.py
@@ -96,7 +96,7 @@ def _main():
         metavar="<report>",
         action="append",
         default=[],
-        choices=["all", "summary", "clustering", "duplicates", "files"],
+        choices=["all", "summary", "clustering", "duplicates"],
         help=_help_string(
             "Generate a report of the specified type:",
             "- summary: code divergence information",
@@ -245,10 +245,6 @@ def _main():
     # Print summary report
     if report_enabled("summary"):
         report.summary(setmap)
-
-    # Print files report
-    if report_enabled("files"):
-        report.files(codebase, state)
 
     # Print clustering report
     if report_enabled("clustering"):

--- a/codebasin/report.py
+++ b/codebasin/report.py
@@ -748,7 +748,9 @@ class FileTree:
 def files(
     codebase: CodeBase,
     state: ParserState | None = None,
+    *,
     stream: TextIO = sys.stdout,
+    prune: bool = False,
 ):
     """
     Produce a file tree representing the code base.
@@ -787,6 +789,11 @@ def files(
             ):
                 platform = frozenset(association[node])
                 setmap[platform] += node.num_lines
+        if prune:
+            # Prune unused files from the tree.
+            platforms = set().union(*setmap.keys())
+            if len(platforms) == 0:
+                continue
         tree.insert(f, setmap)
 
     # Print a legend.

--- a/codebasin/report.py
+++ b/codebasin/report.py
@@ -789,9 +789,6 @@ def files(
                 setmap[platform] += node.num_lines
         tree.insert(f, setmap)
 
-    print("", file=stream)
-    print(_heading("Files", stream), file=stream)
-
     # Print a legend.
     legend = []
     legend += ["Legend:"]

--- a/codebasin/tree.py
+++ b/codebasin/tree.py
@@ -70,6 +70,17 @@ def _build_parser() -> argparse.ArgumentParser:
         help=_help_string(
             "Prune unused files from the tree.",
             is_long=True,
+        ),
+    )
+    parser.add_argument(
+        "-L",
+        "--levels",
+        dest="levels",
+        metavar="<level>",
+        type=int,
+        help=_help_string(
+            "Print only the specified number of levels.",
+            is_long=True,
             is_last=True,
         ),
     )
@@ -88,6 +99,10 @@ def _build_parser() -> argparse.ArgumentParser:
 
 
 def _tree(args: argparse.Namespace):
+    # Refuse to print a tree with no levels, consistent with tree utility.
+    if args.levels is not None and args.levels <= 0:
+        raise ValueError("Number of levels must be greater than 0.")
+
     # TODO: Refactor this to avoid duplication in __main__
     # Determine the root directory based on where codebasin is run.
     rootdir = os.path.abspath(os.getcwd())
@@ -140,7 +155,7 @@ def _tree(args: argparse.Namespace):
     )
 
     # Print the file tree.
-    report.files(codebase, state, prune=args.prune)
+    report.files(codebase, state, prune=args.prune, levels=args.levels)
     sys.exit(0)
 
 

--- a/codebasin/tree.py
+++ b/codebasin/tree.py
@@ -61,6 +61,15 @@ def _build_parser() -> argparse.ArgumentParser:
             "May be specified multiple times.",
             "If not specified, all platforms will be included.",
             is_long=True,
+        ),
+    )
+    parser.add_argument(
+        "--prune",
+        dest="prune",
+        action="store_true",
+        help=_help_string(
+            "Prune unused files from the tree.",
+            is_long=True,
             is_last=True,
         ),
     )
@@ -131,7 +140,7 @@ def _tree(args: argparse.Namespace):
     )
 
     # Print the file tree.
-    report.files(codebase, state)
+    report.files(codebase, state, prune=args.prune)
     sys.exit(0)
 
 

--- a/codebasin/tree.py
+++ b/codebasin/tree.py
@@ -69,7 +69,6 @@ def _build_parser() -> argparse.ArgumentParser:
         action="store_true",
         help=_help_string(
             "Prune unused files from the tree.",
-            is_long=True,
         ),
     )
     parser.add_argument(

--- a/codebasin/tree.py
+++ b/codebasin/tree.py
@@ -140,19 +140,8 @@ def cli(argv: list[str]) -> int:
     args = parser.parse_args(argv)
 
     # Configure logging such that:
-    # - All messages are written to a log file
     # - Only errors are written to the terminal
     log.setLevel(logging.DEBUG)
-
-    file_handler = logging.FileHandler("cbi.log", mode="w")
-    file_handler.setLevel(logging.INFO)
-    file_handler.setFormatter(Formatter())
-    log.addHandler(file_handler)
-
-    # Inform the user that a log file has been created.
-    # 'print' instead of 'log' to ensure the message is visible in the output.
-    log_path = os.path.abspath("cbi.log")
-    print(f"Log file created at {log_path}")
 
     stderr_handler = logging.StreamHandler(sys.stderr)
     stderr_handler.setLevel(logging.ERROR)

--- a/codebasin/tree.py
+++ b/codebasin/tree.py
@@ -1,0 +1,175 @@
+#!/usr/bin/env python3
+# Copyright (C) 2019-2024 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+
+import argparse
+import logging
+import os
+import sys
+
+from codebasin import CodeBase, config, finder, report, util
+
+# TODO: Refactor to avoid imports from __main__
+from codebasin.__main__ import Formatter, _help_string, version
+
+log = logging.getLogger("codebasin")
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """
+    Build argument parser.
+    """
+    parser = argparse.ArgumentParser(
+        description="CBI Tree Tool " + version,
+        formatter_class=argparse.RawTextHelpFormatter,
+        add_help=False,
+    )
+    parser.add_argument(
+        "-h",
+        "--help",
+        action="help",
+        help=_help_string("Display help message and exit."),
+    )
+    parser.add_argument(
+        "--version",
+        action="version",
+        version=f"CBI Coverage Tool {version}",
+        help=_help_string("Display version information and exit."),
+    )
+    parser.add_argument(
+        "-x",
+        "--exclude",
+        dest="excludes",
+        metavar="<pattern>",
+        action="append",
+        default=[],
+        help=_help_string(
+            "Exclude files matching this pattern from the code base.",
+            "May be specified multiple times.",
+            is_long=True,
+        ),
+    )
+    parser.add_argument(
+        "-p",
+        "--platform",
+        dest="platforms",
+        metavar="<platform>",
+        action="append",
+        default=[],
+        help=_help_string(
+            "Include the specified platform in the analysis.",
+            "May be specified multiple times.",
+            "If not specified, all platforms will be included.",
+            is_long=True,
+            is_last=True,
+        ),
+    )
+
+    parser.add_argument(
+        "analysis_file",
+        metavar="<analysis-file>",
+        help=_help_string(
+            "TOML file describing the analysis to be performed, "
+            + "including the codebase and platform descriptions.",
+            is_last=True,
+        ),
+    )
+
+    return parser
+
+
+def _tree(args: argparse.Namespace):
+    # TODO: Refactor this to avoid duplication in __main__
+    # Determine the root directory based on where codebasin is run.
+    rootdir = os.path.abspath(os.getcwd())
+
+    # Set up a default configuration object.
+    configuration = {}
+
+    # Load the analysis file if it exists.
+    if args.analysis_file is not None:
+        path = os.path.abspath(args.analysis_file)
+        if os.path.exists(path):
+            if not os.path.splitext(path)[1] == ".toml":
+                raise RuntimeError(f"Analysis file {path} must end in .toml.")
+
+        with open(path, "rb") as f:
+            analysis_toml = util._load_toml(f, "analysis")
+
+        if "codebase" in analysis_toml:
+            if "exclude" in analysis_toml["codebase"]:
+                args.excludes += analysis_toml["codebase"]["exclude"]
+
+        for name in args.platforms:
+            if name not in analysis_toml["platform"].keys():
+                raise KeyError(
+                    f"Platform {name} requested on the command line "
+                    + "does not exist in the configuration file.",
+                )
+
+        cmd_platforms = args.platforms.copy()
+        for name in analysis_toml["platform"].keys():
+            if cmd_platforms and name not in cmd_platforms:
+                continue
+            if "commands" not in analysis_toml["platform"][name]:
+                raise ValueError(f"Missing 'commands' for platform {name}")
+            p = analysis_toml["platform"][name]["commands"]
+            db = config.load_database(p, rootdir)
+            args.platforms.append(name)
+            configuration.update({name: db})
+
+    # Construct a codebase object associated with the root directory.
+    codebase = CodeBase(rootdir, exclude_patterns=args.excludes)
+
+    # Parse the source tree, and determine source line associations.
+    # The trees and associations are housed in state.
+    state = finder.find(
+        rootdir,
+        codebase,
+        configuration,
+        show_progress=True,
+    )
+
+    # Print the file tree.
+    report.files(codebase, state)
+    sys.exit(0)
+
+
+def cli(argv: list[str]) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    # Configure logging such that:
+    # - All messages are written to a log file
+    # - Only errors are written to the terminal
+    log.setLevel(logging.DEBUG)
+
+    file_handler = logging.FileHandler("cbi.log", mode="w")
+    file_handler.setLevel(logging.INFO)
+    file_handler.setFormatter(Formatter())
+    log.addHandler(file_handler)
+
+    # Inform the user that a log file has been created.
+    # 'print' instead of 'log' to ensure the message is visible in the output.
+    log_path = os.path.abspath("cbi.log")
+    print(f"Log file created at {log_path}")
+
+    stderr_handler = logging.StreamHandler(sys.stderr)
+    stderr_handler.setLevel(logging.ERROR)
+    stderr_handler.setFormatter(Formatter(colors=sys.stderr.isatty()))
+    log.addHandler(stderr_handler)
+
+    return _tree(args)
+
+
+def main():
+    try:
+        cli(sys.argv[1:])
+    except Exception as e:
+        log.error(str(e))
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    sys.argv[0] = "codebasin.tree"
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,7 @@ dependencies = [
 [project.scripts]
 codebasin = "codebasin:__main__.main"
 cbi-cov = "codebasin.coverage:__main__.main"
+cbi-tree = "codebasin:tree.main"
 
 [project.urls]
 "Github" = "https://www.github.com/intel/code-base-investigator"


### PR DESCRIPTION
# Related issues

- Closes #152. 

# Proposed changes

- Remove `-R tree` option from `codebasin`, replacing it with a standalone `cbi-tree` script.
- Add new `--levels` option inspired by `tree`, which gives users control over how deep the tree should be.
- Add new `--prune` option inspired by `tree`, which gives users control over handling of unused files.

---

@laserkelvin, since you originally requested this functionality, I'd appreciate it if you could download this one and experiment with it a little bit in addition to reviewing the code, to make sure that it behaves the way that you would expect.

I was a little uncertain about the output format, because it's no longer a report that is generated from `codebasin`.  At the time of opening this PR, the output looks like this:

![image](https://github.com/user-attachments/assets/927b842a-ece7-4026-b4c1-b3a375609f9b)

...where we lose quite a lot of vertical space to the legend and column headings.  Utilities like `ls -l` and `tree` don't provide any sort of explanation as part of their default output, and I wonder if we should follow that precedent.  For example, is this better:

![image](https://github.com/user-attachments/assets/e0c571a9-1f8d-4865-a0a9-0bcea7e02789)
