### PR TITLE
Add compiler definitions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,7 @@
+include codebasin/compilers/clang.toml
+include codebasin/compilers/gnu.toml
+include codebasin/compilers/intel.toml
+include codebasin/compilers/nvidia.toml
 include codebasin/schema/analysis.schema
 include codebasin/schema/compilation-database.schema
 include codebasin/schema/coverage.schema

--- a/codebasin/compilers/clang.toml
+++ b/codebasin/compilers/clang.toml
@@ -1,0 +1,20 @@
+[compiler.clang]
+
+[compiler."clang++"]
+alias_of = "clang"
+
+[[compiler.clang.parser]]
+flags = ["-fopenmp"]
+action = "append_const"
+dest = "modes"
+const = "openmp"
+
+[[compiler.clang.parser]]
+flags = ["-fsycl-is-device"]
+action = "append_const"
+dest = "defines"
+const = "__SYCL_DEVICE_ONLY__"
+
+[[compiler.clang.modes]]
+name = "openmp"
+defines = ["_OPENMP"]

--- a/codebasin/compilers/gnu.toml
+++ b/codebasin/compilers/gnu.toml
@@ -1,0 +1,14 @@
+[compiler.gcc]
+
+[compiler."g++"]
+alias_of = "gcc"
+
+[[compiler.gcc.parser]]
+flags = ["-fopenmp"]
+action = "append_const"
+dest = "modes"
+const = "openmp"
+
+[[compiler.gcc.modes]]
+name = "openmp"
+defines = ["_OPENMP"]

--- a/codebasin/compilers/intel.toml
+++ b/codebasin/compilers/intel.toml
@@ -1,0 +1,52 @@
+[compiler.icx]
+
+[compiler.icpx]
+alias_of = "icx"
+
+[[compiler.icx.parser]]
+flags = ["-fopenmp"]
+action = "append_const"
+dest = "modes"
+const = "openmp"
+
+[[compiler.icx.parser]]
+flags = ["-fsycl"]
+action = "append_const"
+dest = "modes"
+const = "sycl"
+
+[[compiler.icx.parser]]
+flags = ["-fsycl-targets"]
+action = "store_split"
+sep = ","
+format = "sycl-$value"
+dest = "passes"
+default = ["sycl-spir64"]
+
+[[compiler.icx.modes]]
+name = "sycl"
+defines = ["SYCL_LANGUAGE_VERSION"]
+
+[[compiler.icx.modes]]
+name = "openmp"
+defines = ["_OPENMP"]
+
+[[compiler.icx.passes]]
+name = "sycl-spir64"
+defines = ["__SYCL_DEVICE_ONLY__", "__SPIR__", "__SPIRV__"]
+modes = ["sycl"]
+
+[[compiler.icx.passes]]
+name = "sycl-spir64_x86_64"
+defines = ["__SYCL_DEVICE_ONLY__", "__SPIR__", "__SPIRV__"]
+modes = ["sycl"]
+
+[[compiler.icx.passes]]
+name = "sycl-spir64_gen"
+defines = ["__SYCL_DEVICE_ONLY__", "__SPIR__", "__SPIRV__"]
+modes = ["sycl"]
+
+[[compiler.icx.passes]]
+name = "sycl-spir64_fpga"
+defines = ["__SYCL_DEVICE_ONLY__", "__SPIR__", "__SPIRV__"]
+modes = ["sycl"]

--- a/codebasin/compilers/nvidia.toml
+++ b/codebasin/compilers/nvidia.toml
@@ -1,0 +1,41 @@
+[compiler.nvcc]
+options = ["-D__NVCC__", "-D__CUDACC__"]
+
+[[compiler.nvcc.parser]]
+flags = ["-fopenmp"]
+action = "append_const"
+dest = "modes"
+const = "openmp"
+
+[[compiler.nvcc.parser]]
+flags = ["--gpu-architecture", "--gpu-code", "-gencode"]
+action = "extend_match"
+pattern = '(?:sm_|compute_)(\d+)'
+format = "sm_$value"
+dest = "passes"
+default = ["sm_70"]
+override = true
+
+[[compiler.nvcc.modes]]
+name = "openmp"
+defines = ["_OPENMP"]
+
+[[compiler.nvcc.passes]]
+name = "sm_70"
+defines = ["__CUDA_ARCH__=700"]
+
+[[compiler.nvcc.passes]]
+name = "sm_75"
+defines = ["__CUDA_ARCH__=750"]
+
+[[compiler.nvcc.passes]]
+name = "sm_80"
+defines = ["__CUDA_ARCH__=800"]
+
+[[compiler.nvcc.passes]]
+name = "sm_89"
+defines = ["__CUDA_ARCH__=890"]
+
+[[compiler.nvcc.passes]]
+name = "sm_90"
+defines = ["__CUDA_ARCH__=900"]


### PR DESCRIPTION
# Related issues

- Part of #145. 

# Proposed changes

- Define a TOML file in `codebasin/compilers/` for each recognized compiler.
- Add the code necessary for loading these compilers into a useful structure.
- Load the contents of the TOML files into a global `_compilers` variable when `config` is imported.

---

This doesn't actually achieve anything, in the sense that the `_compilers` variable remains unused.  However, this seemed to be a nice chunk to carve out for review: the compiler definitions are (hopefully) straightforward to read; and loading them in upon import is sufficient to test the validation of these files.

Note that there are a few lines that are not covered by testing. These are the lines which print an error message when the TOML files are missing from the package, and I don't think there's an easy way to test that.