### PR TITLE
Fix several issues with custom argparse actions

### DIFF
--- a/codebasin/config.py
+++ b/codebasin/config.py
@@ -105,7 +105,7 @@ class _StoreSplitAction(argparse.Action):
             template = string.Template(self.format)
             split_values = [template.substitute(value=v) for v in split_values]
         if self.dest == "passes":
-            passes = getattr(namespace, self.dest)
+            passes = getattr(namespace, "_passes")
             passes[option_string] = split_values
         else:
             setattr(namespace, self.dest, split_values)
@@ -144,7 +144,7 @@ class _ExtendMatchAction(argparse.Action):
             template = string.Template(self.format)
             matches = [template.substitute(value=v) for v in matches]
         if self.dest == "passes":
-            passes = getattr(namespace, self.dest)
+            passes = getattr(namespace, "_passes")
             if self.flag_name not in passes:
                 passes[self.flag_name] = []
             if self.override:

--- a/codebasin/config.py
+++ b/codebasin/config.py
@@ -126,6 +126,7 @@ class _ExtendMatchAction(argparse.Action):
     ):
         self.pattern = kwargs.pop("pattern", None)
         self.format = kwargs.pop("format", None)
+        self.override = kwargs.pop("override", False)
         self.flag_name = option_strings[0]
         super().__init__(option_strings, dest, nargs=nargs, **kwargs)
 
@@ -146,10 +147,17 @@ class _ExtendMatchAction(argparse.Action):
             passes = getattr(namespace, self.dest)
             if self.flag_name not in passes:
                 passes[self.flag_name] = []
-            passes[self.flag_name].extend(matches)
+            if self.override:
+                passes[self.flag_name] = matches
+                self.override = False
+            else:
+                passes[self.flag_name].extend(matches)
         else:
-            dest = getattr(namespace, self.dest)
-            dest.extend(matches)
+            if self.override:
+                setattr(namespace, self.dest, matches)
+            else:
+                dest = getattr(namespace, self.dest)
+                dest.extend(matches)
 
 
 @dataclass

--- a/codebasin/config.py
+++ b/codebasin/config.py
@@ -126,6 +126,7 @@ class _ExtendMatchAction(argparse.Action):
     ):
         self.pattern = kwargs.pop("pattern", None)
         self.format = kwargs.pop("format", None)
+        self.flag_name = option_strings[0]
         super().__init__(option_strings, dest, nargs=nargs, **kwargs)
 
     def __call__(
@@ -143,9 +144,9 @@ class _ExtendMatchAction(argparse.Action):
             matches = [template.substitute(value=v) for v in matches]
         if self.dest == "passes":
             passes = getattr(namespace, self.dest)
-            if option_string not in passes:
-                passes[option_string] = []
-            passes[option_string].extend(matches)
+            if self.flag_name not in passes:
+                passes[self.flag_name] = []
+            passes[self.flag_name].extend(matches)
         else:
             dest = getattr(namespace, self.dest)
             dest.extend(matches)

--- a/tests/compilers/test_actions.py
+++ b/tests/compilers/test_actions.py
@@ -30,7 +30,7 @@ class TestActions(unittest.TestCase):
     def test_store_split(self):
         """Check that argparse calls store_split correctly"""
         namespace = argparse.Namespace()
-        namespace.passes = {}
+        namespace._passes = {}
 
         parser = argparse.ArgumentParser()
         parser.add_argument("--foo", action=_StoreSplitAction, sep=",")
@@ -58,7 +58,7 @@ class TestActions(unittest.TestCase):
             args, _ = parser.parse_known_args(["--baz=1"], namespace)
 
         args, _ = parser.parse_known_args(["--qux=one,two"], namespace)
-        self.assertEqual(args.passes, {"--qux": ["one", "two"]})
+        self.assertEqual(args._passes, {"--qux": ["one", "two"]})
 
     def test_extend_match_init(self):
         """Check that extend_match recognizes custom arguments"""
@@ -127,30 +127,30 @@ class TestActions(unittest.TestCase):
 
         # Check that the default pass defined by --qux always exists.
         # Note that the caller must initialize the default.
-        namespace.passes = {"--qux": ["0"]}
+        namespace._passes = {"--qux": ["0"]}
         args, _ = parser.parse_known_args(
             [],
             namespace,
         )
-        self.assertEqual(args.passes, {"--qux": ["0"]})
+        self.assertEqual(args._passes, {"--qux": ["0"]})
 
         # Check that the default pass is overridden by use of --qux.
         # Note that the caller must initialize the default.
-        namespace.passes = {"--qux": ["0"]}
+        namespace._passes = {"--qux": ["0"]}
         args, _ = parser.parse_known_args(
             ["--qux=option_1,option_2"],
             namespace,
         )
-        self.assertEqual(args.passes, {"--qux": ["1", "2"]})
+        self.assertEqual(args._passes, {"--qux": ["1", "2"]})
 
-        namespace.passes = {}
+        namespace._passes = {}
         args, _ = parser.parse_known_args(
             ["--one=option_1", "--two=option_2"],
             namespace,
         )
-        self.assertEqual(args.passes, {"--one": ["1", "2"]})
+        self.assertEqual(args._passes, {"--one": ["1", "2"]})
 
-        namespace.passes = {}
+        namespace._passes = {}
 
 
 if __name__ == "__main__":

--- a/tests/compilers/test_actions.py
+++ b/tests/compilers/test_actions.py
@@ -99,6 +99,8 @@ class TestActions(unittest.TestCase):
             action=_ExtendMatchAction,
             pattern=r"option_(\d+)",
             dest="passes",
+            default=["0"],
+            override=True,
         )
         parser.add_argument(
             "--one",
@@ -123,7 +125,18 @@ class TestActions(unittest.TestCase):
         with self.assertRaises(TypeError):
             args, _ = parser.parse_known_args(["--baz=1"], namespace)
 
-        namespace.passes = {}
+        # Check that the default pass defined by --qux always exists.
+        # Note that the caller must initialize the default.
+        namespace.passes = {"--qux": ["0"]}
+        args, _ = parser.parse_known_args(
+            [],
+            namespace,
+        )
+        self.assertEqual(args.passes, {"--qux": ["0"]})
+
+        # Check that the default pass is overridden by use of --qux.
+        # Note that the caller must initialize the default.
+        namespace.passes = {"--qux": ["0"]}
         args, _ = parser.parse_known_args(
             ["--qux=option_1,option_2"],
             namespace,
@@ -136,6 +149,8 @@ class TestActions(unittest.TestCase):
             namespace,
         )
         self.assertEqual(args.passes, {"--one": ["1", "2"]})
+
+        namespace.passes = {}
 
 
 if __name__ == "__main__":

--- a/tests/compilers/test_actions.py
+++ b/tests/compilers/test_actions.py
@@ -78,7 +78,6 @@ class TestActions(unittest.TestCase):
     def test_extend_match(self):
         """Check that argparse calls store_split correctly"""
         namespace = argparse.Namespace()
-        namespace.passes = {}
 
         parser = argparse.ArgumentParser()
         parser.add_argument(
@@ -101,6 +100,13 @@ class TestActions(unittest.TestCase):
             pattern=r"option_(\d+)",
             dest="passes",
         )
+        parser.add_argument(
+            "--one",
+            "--two",
+            action=_ExtendMatchAction,
+            pattern=r"option_(\d+)",
+            dest="passes",
+        )
 
         args, _ = parser.parse_known_args(
             ["--foo=option_1,option_2"],
@@ -117,11 +123,19 @@ class TestActions(unittest.TestCase):
         with self.assertRaises(TypeError):
             args, _ = parser.parse_known_args(["--baz=1"], namespace)
 
+        namespace.passes = {}
         args, _ = parser.parse_known_args(
             ["--qux=option_1,option_2"],
             namespace,
         )
         self.assertEqual(args.passes, {"--qux": ["1", "2"]})
+
+        namespace.passes = {}
+        args, _ = parser.parse_known_args(
+            ["--one=option_1", "--two=option_2"],
+            namespace,
+        )
+        self.assertEqual(args.passes, {"--one": ["1", "2"]})
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Related issues

- Part of #145. 
- Required to properly handle actions as defined in #168.

# Proposed changes

- Support multiple flags in `ExtendMatch` (e.g., `flags = ["--gpu-architecture", "--gpu-code", "-gencode"]`).
- Add `override` option to `ExtendMatch`, enabling a flag to define a default value that is removed from the result list when the flag is specified. (This was surprisingly difficult to achieve, and cannot be achieved with `argparse` alone!).
- Force custom actions to write to a separate "passes" destination than built-in actions, to ensure that our special handling of this variable doesn't interfere with standard `argparse` behaviors.
- Add tests for each of the cases above.

Note that there are more detailed explanations of each of these changes in the commit messages.

---

These custom actions still aren't used by any code except tests.  There is some special setup required in order to use the actions correctly, but this is fine because they are implementation details (note the leading underscore). The `ArgumentParser` that I'll be committing after this functionality is merged handles this setup transparently to the user.
