### PR TITLE
Fix bug in handling of unsigned constants

### DIFF
--- a/codebasin/preprocessor.py
+++ b/codebasin/preprocessor.py
@@ -2002,7 +2002,7 @@ class ExpressionEvaluator(Parser):
             # Convert to decimal and then to integer with correct sign
             # Preprocessor always uses 64-bit arithmetic!
             int_value = int(value, base)
-            if suffix and "u" in suffix:
+            if suffix and "u" in suffix.lower():
                 return np.uint64(int_value)
             else:
                 return np.int64(int_value)

--- a/tests/literals/test_literals.py
+++ b/tests/literals/test_literals.py
@@ -5,6 +5,8 @@ import logging
 import unittest
 from pathlib import Path
 
+import numpy as np
+
 from codebasin import CodeBase, finder, preprocessor
 
 
@@ -59,6 +61,11 @@ class TestLiterals(unittest.TestCase):
             r"L + 2-2 \"\\\" \\n\"",
         )
         self.assertEqual(tokens[0].token, expected.token)
+
+    def test_long_constants(self):
+        tokens = preprocessor.Lexer("0xFFFFFFFFFFFFFFFFULL").tokenize()
+        term = preprocessor.ExpressionEvaluator(tokens).term()
+        self.assertEqual(term, np.uint64(int("0xFFFFFFFFFFFFFFFF", 16)))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Related issues

- #96; I figured out how to call the preprocessor directly, so we can add new tests without source files.

# Proposed changes

- Add a regression test for a case I found in a real code, where `0xFFFFFFFFFFFFFFFFULL` was leading to an overflow.
- Convert number suffixes (e.g., "ull", "ULL") to lower case before checking if they contain "u".

---

I also considered:
```python
if suffix and ("u" in suffix or "U" in suffix):
```

...but converting to lower-case was shorter.
