### PR TITLE
Recommend using cmake -G Ninja in the tutorial

### DIFF
--- a/docs/source/compilation-databases.rst
+++ b/docs/source/compilation-databases.rst
@@ -54,10 +54,16 @@ obtain a compilation database for the CPU:
 .. code :: sh
 
     $ mkdir build-cpu
-    $ cmake ../
+    $ cmake -G Ninja ../
     $ ls
 
     CMakeCache.txt  CMakeFiles  Makefile  cmake_install.cmake  compile_commands.json
+
+.. tip::
+    Using the "Ninja" generator is not required, but is often faster and can
+    improve the quality of CBI's results. Other generators (such as "Unix
+    Makefiles") may use response (:code:`.rsp`) files to pass command-line
+    options, and any options passed this way will not be respected by CBI.
 
 This :code:`compile_commands.json` file includes all the commands required to
 build the code, corresponding to the commands that would be executed if we were


### PR DESCRIPTION
It turns out that some generators (like Unix Makefiles) automatically compress command-lines using response (.rsp) files if they exceed a certain number of characters. There is no way to disable this behavior, and it is language-specific.

Any options that are hidden inside an .rsp file is passed to the compiler using a compiler-specific option, and the .rsp file itself may not exist when we try to run our analysis.

Using Ninja avoids this issue, and thus produces better results.

# Related issues

N/A

# Proposed changes

- Add `-G Ninja` to the example command-line, so that people who follow the tutorial will use Ninja.
- Add a "tip" callout to explain why we're using Ninja in the tutorial.
