### PR TITLE
Switch to finalized coverage schema

### DIFF
--- a/codebasin/coverage/__main__.py
+++ b/codebasin/coverage/__main__.py
@@ -133,19 +133,22 @@ def _compute(args: argparse.Namespace):
         with open(filename, "rb") as f:
             digest = hashlib.file_digest(f, "sha512")
 
-        lines = []
+        used_lines = []
+        unused_lines = []
         tree = state.get_tree(filename)
         association = state.get_map(filename)
         for node in [n for n in tree.walk() if isinstance(n, CodeNode)]:
             if association[node] == frozenset([]):
-                continue
-            lines.extend(node.lines)
+                unused_lines.extend(node.lines)
+            else:
+                used_lines.extend(node.lines)
 
         covarray.append(
             {
                 "file": relative_path,
                 "id": digest.hexdigest(),
-                "lines": lines,
+                "used_lines": used_lines,
+                "unused_lines": unused_lines,
             },
         )
 

--- a/codebasin/schema/coverage.schema
+++ b/codebasin/schema/coverage.schema
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://raw.githubusercontent.com/intel/p3-analysis-library/main/p3/data/coverage-0.3.0.schema",
+  "$id": "https://raw.githubusercontent.com/intel/p3-analysis-library/main/p3/data/coverage.schema",
   "title": "Coverage",
   "description": "Lines of code used in each file of a code base.",
   "type": "array",
@@ -13,29 +13,24 @@
       "id": {
         "type": "string"
       },
-      "lines": {
+      "used_lines": {
         "type": "array",
         "items": {
-            "oneOf": [
-                {
-                    "type": "integer"
-                },
-                {
-                    "type": "array",
-                    "contains": {
-                        "type": "integer"
-                    },
-                    "minContains": 2,
-                    "maxContains": 2
-                }
-            ]
+            "type": "integer"
+        }
+      },
+      "unused_lines": {
+        "type": "array",
+        "items": {
+            "type": "integer"
         }
       }
     },
     "required": [
       "file",
       "id",
-      "lines"
+      "used_lines",
+      "unused_lines"
     ]
   }
 }

--- a/tests/cli/test_cbicov.py
+++ b/tests/cli/test_cbicov.py
@@ -97,12 +97,14 @@ class TestCbiCov(unittest.TestCase):
             {
                 "file": "bar.h",
                 "id": "3ba8372282f8f1bafc59bb3d0472dcd7ecd5f13a54f17585c6012bfc40bfba7b9afb905f24ccea087546f4c90363bba97d988e4067ec880f619d0ab623c3a7a1",  # noqa: E501
-                "lines": [],
+                "used_lines": [],
+                "unused_lines": [1],
             },
             {
                 "file": "foo.cpp",
                 "id": "1359957a144db36091624c1091ac6a47c47945a3ff63a47ace3dc5c1b13159929adac14c21733ec1054f7f1f8809ac416e643483191aab6687d7849ee17edaa0",  # noqa: E501
-                "lines": [1, 3, 4],
+                "used_lines": [1, 3, 4],
+                "unused_lines": [2],
             },
         ]
         self.assertCountEqual(coverage, expected_coverage)


### PR DESCRIPTION
# Related issues

- Closes #165.
- Aligned with https://github.com/intel/p3-analysis-library/pull/75.

# Proposed changes

- Copy across the schema from the P3 Analysis Library.
- Generate `used_lines` and `unused_lines` when invoking `cbi-cov`.
- Update the `cbi-cov` tests.

---

@laserkelvin, I've opened this as a draft because I want to make sure that you're happy with https://github.com/intel/p3-analysis-library/pull/75, and I don't want this to accidentally get merged first.  I've opened it early primarily so you have the option to run something that can generate the new coverage format.