### PR TITLE
Generate version string dynamically

### DIFF
--- a/codebasin/__init__.py
+++ b/codebasin/__init__.py
@@ -1,5 +1,6 @@
 # Copyright (C) 2019-2024 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
+import importlib.metadata
 import os
 import shlex
 import warnings
@@ -18,6 +19,8 @@ warnings.warn(
     + "a future release of Code Base Investigator.",
     DeprecationWarning,
 )
+
+__version__ = importlib.metadata.version("codebasin")
 
 
 class CompileCommand:

--- a/codebasin/__main__.py
+++ b/codebasin/__main__.py
@@ -6,6 +6,7 @@ This script is the main executable of Code Base Investigator.
 """
 
 import argparse
+import importlib.metadata
 import logging
 import os
 import sys
@@ -14,7 +15,7 @@ from codebasin import CodeBase, config, finder, report, util
 from codebasin._detail.logging import Formatter, WarningAggregator
 
 log = logging.getLogger("codebasin")
-version = "1.2.0"
+version = importlib.metadata.version("codebasin")
 
 _traceback = False
 

--- a/codebasin/__main__.py
+++ b/codebasin/__main__.py
@@ -6,16 +6,14 @@ This script is the main executable of Code Base Investigator.
 """
 
 import argparse
-import importlib.metadata
 import logging
 import os
 import sys
 
-from codebasin import CodeBase, config, finder, report, util
+from codebasin import CodeBase, __version__, config, finder, report, util
 from codebasin._detail.logging import Formatter, WarningAggregator
 
 log = logging.getLogger("codebasin")
-version = importlib.metadata.version("codebasin")
 
 _traceback = False
 
@@ -60,7 +58,7 @@ def _help_string(*lines: str, is_long=False, is_last=False):
 def _main():
     # Read command-line arguments
     parser = argparse.ArgumentParser(
-        description="Code Base Investigator " + str(version),
+        description="Code Base Investigator " + str(__version__),
         formatter_class=argparse.RawTextHelpFormatter,
         add_help=False,
     )
@@ -73,7 +71,7 @@ def _main():
     parser.add_argument(
         "--version",
         action="version",
-        version=f"Code Base Investigator {version}",
+        version=f"Code Base Investigator {__version__}",
         help=_help_string("Display version information and exit."),
     )
     parser.add_argument(
@@ -181,7 +179,9 @@ def _main():
     log.addHandler(file_handler)
 
     if args.debug:
-        log.debug(f"Code Base Investigator {version}; Python {sys.version}")
+        log.debug(
+            f"Code Base Investigator {__version__}; Python {sys.version}",
+        )
 
     # Inform the user that a log file has been created.
     # 'print' instead of 'log' to ensure the message is visible in the output.

--- a/codebasin/coverage/__main__.py
+++ b/codebasin/coverage/__main__.py
@@ -9,15 +9,10 @@ import logging
 import os
 import sys
 
-from codebasin import CodeBase, config, finder, util
+from codebasin import CodeBase, __version__, config, finder, util
 
 # TODO: Refactor to avoid imports from __main__
-from codebasin.__main__ import (
-    Formatter,
-    WarningAggregator,
-    _help_string,
-    version,
-)
+from codebasin.__main__ import Formatter, WarningAggregator, _help_string
 from codebasin.preprocessor import CodeNode
 
 log = logging.getLogger("codebasin")
@@ -28,7 +23,7 @@ def _build_parser() -> argparse.ArgumentParser:
     Build argument parser.
     """
     parser = argparse.ArgumentParser(
-        description="CBI Coverage Tool " + version,
+        description="CBI Coverage Tool " + __version__,
         formatter_class=argparse.RawTextHelpFormatter,
         add_help=False,
     )
@@ -42,7 +37,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--version",
         action="version",
-        version=f"CBI Coverage Tool {version}",
+        version=f"CBI Coverage Tool {__version__}",
         help="Display version information and exit.",
     )
 

--- a/codebasin/tree.py
+++ b/codebasin/tree.py
@@ -7,10 +7,10 @@ import logging
 import os
 import sys
 
-from codebasin import CodeBase, config, finder, report, util
+from codebasin import CodeBase, __version__, config, finder, report, util
 
 # TODO: Refactor to avoid imports from __main__
-from codebasin.__main__ import Formatter, _help_string, version
+from codebasin.__main__ import Formatter, _help_string
 
 log = logging.getLogger("codebasin")
 
@@ -20,7 +20,7 @@ def _build_parser() -> argparse.ArgumentParser:
     Build argument parser.
     """
     parser = argparse.ArgumentParser(
-        description="CBI Tree Tool " + version,
+        description="CBI Tree Tool " + __version__,
         formatter_class=argparse.RawTextHelpFormatter,
         add_help=False,
     )
@@ -33,7 +33,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--version",
         action="version",
-        version=f"CBI Coverage Tool {version}",
+        version=f"CBI Coverage Tool {__version__}",
         help=_help_string("Display version information and exit."),
     )
     parser.add_argument(

--- a/codebasin/tree.py
+++ b/codebasin/tree.py
@@ -33,7 +33,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         "--version",
         action="version",
-        version=f"CBI Coverage Tool {__version__}",
+        version=f"CBI Tree Tool {__version__}",
         help=_help_string("Display version information and exit."),
     )
     parser.add_argument(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,15 +2,14 @@
 # SPDX-License-Identifier: BSD-3-Clause
 [build-system]
 build-backend = "setuptools.build_meta"
-requires = ["setuptools >= 61.0"]
+requires = ["setuptools>=64", "setuptools-scm>=8"]
 
 [project]
 authors = [
   {"name" = "S. John Pennycook", "email" = "john.pennycook@intel.com"},
 ]
 description = "Code Base Investigator"
-version = "1.2.0"
-dynamic = ["readme"]
+dynamic = ["version", "readme"]
 keywords = ["performance", "portability", "productivity"]
 name = "codebasin"
 requires-python = ">=3.9"
@@ -60,6 +59,9 @@ include = ["codebasin*"]
 
 [tool.setuptools.dynamic]
 readme = {file = ["README.md"]}
+
+[tool.setuptools_scm]
+# Deliberately empty to enable setuptools-scm
 
 [tool.coverage.run]
 command_line = "-m unittest"


### PR DESCRIPTION
# Related issues

- Motivated by #177, since version string is now in the debug log.

# Proposed changes

- Use `importlib` to extract the version metadata from whatever `pip` labelled the package when it was installed.
- Configure `setuptools-scm` to generate the version string automatically from the latest semver tag and git status.
- Move `codebasin.version` to `codebasin.__version__` to align with the convention used by other packages.
- Fix `cbi-tree --version`, which used the string "CBI Coverage Tool" by mistake.

---

The new behavior in action:
```python
>>> import codebasin
>>> codebasin.__version__
'1.2.1.dev313+g63df3e8'
```

```
$ codebasin --version
Code Base Investigator 1.2.1.dev313+g63df3e8
```

```
$ cbi-cov --version
CBI Coverage Tool 1.2.1.dev313+g63df3e8
```

```
$ cbi-tree --version
CBI Tree Tool 1.2.1.dev313+g63df3e8
```