### PR TITLE
Fix condition in FileTree insert

### DIFF
--- a/codebasin/report.py
+++ b/codebasin/report.py
@@ -633,7 +633,7 @@ class FileTree:
                     parent.setmap[ps] += setmap[ps]
 
             # If this name exists, find the node.
-            if parent is not None and path.name in parent.children:
+            if path.name in parent.children:
                 node = parent.children[path.name]
 
             # Otherwise, create the node.


### PR DESCRIPTION
This is a holdover from a previous implementation, where the root tree was created by a call to insert. The newest code creates the root node explicitly when the FileTree object is created, and parent can never be None.

# Related issues

N/A

# Proposed changes

- Remove unnecessary check of whether `parent` is None.
