### PR TITLE
Ignore empty .cbi/config files

### DIFF
--- a/codebasin/config.py
+++ b/codebasin/config.py
@@ -198,6 +198,10 @@ def _load_compilers():
                 log.error(str(e))
                 return
 
+        # Ignore empty configuration files.
+        if "compiler" not in toml:
+            return
+
         for name, definition in toml["compiler"].items():
             # Check if the user is defining a new compiler.
             if name not in _compilers:

--- a/tests/compilers/test_compilers.py
+++ b/tests/compilers/test_compilers.py
@@ -422,6 +422,16 @@ class TestCompilers(unittest.TestCase):
 
         tmp.cleanup()
 
+    def test_empty_config(self):
+        """Check that we ignore empty configuration files."""
+        tmp = tempfile.TemporaryDirectory()
+        path = Path(tmp.name)
+        os.chdir(tmp.name)
+        os.mkdir(".cbi")
+        open(path / ".cbi" / "config", mode="w").close()
+        config._load_compilers()
+        tmp.cleanup()
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
# Related issues

N/A

# Proposed changes

- Add regression test for empty .cbi/config files.
- Ignore empty .cbi/config files.
