### PR TITLE
Defer .cbi/config loading until required

### DIFF
--- a/codebasin/config.py
+++ b/codebasin/config.py
@@ -249,11 +249,6 @@ def _load_compilers():
                     compiler.passes[name] = _CompilerPass.from_toml(p)
 
 
-# Load the compiler configuration when this module is imported.
-if not _compilers:
-    _load_compilers()
-
-
 @dataclass
 class PreprocessorConfiguration:
     """
@@ -292,6 +287,10 @@ class ArgumentParser:
 
     def __init__(self, path: str):
         self.name = os.path.basename(path)
+
+        # Load the global compiler configuration if necessary.
+        if not _compilers:
+            _load_compilers()
 
         self.compiler = _Compiler()
         if self.name not in _compilers:


### PR DESCRIPTION
Loading the configuration file when the module is imported can lead to a situation where an exception is thrown before logging is configured.

# Related issues

N/A

# Proposed changes

- Do not load .cbi/config when the `config` module is imported.
- Check to see if `_compilers` needs to be populated the first time we create an `ArgumentParser`.

---

The configuration file probably _should_ be loaded when `codebasin` is imported, but it's currently not an easy fix due to some circular imports. The fix I'm proposing here is sufficient for 2.0.0, I think, but we should identify a better long-term fix as part of #172.
