### PR TITLE
Add documentation for new features

### DIFF
--- a/docs/source/analysis.rst
+++ b/docs/source/analysis.rst
@@ -104,6 +104,100 @@ platforms. Plugging these numbers into the equation for code divergence gives
     not to (more on that later).
 
 
+Running ``cbi-tree``
+####################
+
+Running ``codebasin`` provides an overview of divergence and coverage, which
+can be useful when we want to familiarize ourselves with a new code base,
+compare the impact of different code structures upon certain metrics, or track
+specialization metrics over time. However, it doesn't provide any *actionable*
+insight into how to improve a code base.
+
+To understand how much specialization exists in each source file, we can
+substitute ``codebasin`` for ``cbi-tree``::
+
+    $ cbi-tree analysis.toml
+
+This command performs the same analysis as ``codebasin``, but produces a tree
+annotated with information about which files contain specialization:
+
+.. code-block:: text
+   :emphasize-lines: 8,9,11,16
+
+    Legend:
+    A: cpu
+    B: gpu
+
+    Columns:
+    [Platforms | SLOC | Coverage (%) | Avg. Coverage (%)]
+
+    [AB | 33 |  93.94 |  72.73] o /home/username/code-base-investigator/docs/sample-code-base/src/
+    [AB | 13 | 100.00 |  92.31] ├── main.cpp
+    [A- |  7 |  85.71 |  42.86] ├─o cpu/
+    [A- |  7 |  85.71 |  42.86] │ └── foo.cpp
+    [AB |  6 | 100.00 | 100.00] ├─o third-party/
+    [AB |  1 | 100.00 | 100.00] │ ├── library.h
+    [AB |  5 | 100.00 | 100.00] │ └── library.cpp
+    [-B |  7 |  85.71 |  42.86] └─o gpu/
+    [-B |  7 |  85.71 |  42.86]   └── foo.cpp
+
+.. tip::
+
+    Running ``cbi-tree`` in a modern terminal environment producers colored
+    output to improve usability for large code bases.
+
+Each node in the tree represents a source file or directory in the code
+base and is annotated with four pieces of information:
+
+1. **Platforms**
+
+   The set of platforms that use the file or directory.
+
+2. **SLOC**
+
+   The number of source lines of code (SLOC) in the file or directory.
+
+3. **Coverage (%)**
+
+   The amount of code in the file or directory that is used by all platforms,
+   as a percentage of SLOC.
+
+4. **Avg. Coverage (%)**
+
+   The amount of code in the file or directory that is used by each platform,
+   on average, as a percentage of SLOC.
+
+The root of the tree represents the entire code base, and so the values in
+the annotations match the ``codebasin`` results: two platforms (``A`` and
+``B``) use the directory, there are 33 lines in total, 93.94% of those lines
+(i.e., 31 lines) are used by at least one platform, and each platform uses
+72.73% of those lines (i.e., 24 lines) on average. By walking the tree, we can
+break these numbers down across the individual files and directories in the
+code base.
+
+Starting with ``main.cpp``, we can see that it is used by both platforms
+(``A`` and ``B``), and that 100% of the 13 lines in the file are used by at
+least one platform. However, the average coverage is only 92.31%, reflecting
+that each platform uses only 12 of those lines.
+
+Turning our attention to ``cpu/foo.cpp`` and ``gpu/foo.cpp``, we can see
+that they are each specialized for one platform (``A`` and ``B``,
+respectively). The coverage for both files is only 85.71% (i.e., 6 of the 7
+lines), which tells us that both files contain some unused code (i.e., 1 line).
+The average coverage of 42.86% highlights the extent of the specialization.
+
+.. tip::
+
+   Looking at average coverage is the best way to identify highly specialized
+   regions of code. As the number of platforms targeted by a code base
+   increases, the average coverage for files used by only a small number of
+   platforms will approach zero.
+
+The remaining files all have a coverage of 100.00% and an average coverage
+of 100.00%. This is our ideal case: all of the code in the file is used by
+at least one platform, and all of the platforms use all of the code.
+
+
 Filtering Platforms
 ###################
 
@@ -125,3 +219,9 @@ platform as follows:
 .. code:: sh
 
     $ codebasin -p cpu analysis.toml
+
+or
+
+.. code:: sh
+
+    $ cbi-tree -p cpu analysis.toml

--- a/docs/source/cmd.rst
+++ b/docs/source/cmd.rst
@@ -43,3 +43,41 @@ Command Line Interface
     Include the specified platform in the analysis.
     May be specified multiple times.
     If not specified, all platforms will be included.
+
+Tree Tool
+---------
+
+The tree tool generates a visualization of the code base where each file and
+directory is annotated with information about platform usage and coverage.
+
+.. code-block:: text
+
+    cbi-tree [-h] [--version] [-x <pattern>] [-p <platform>] [--prune] [-L <level>] <analysis-file>
+
+**positional arguments:**
+
+``analysis-file``
+    TOML file describing the analysis to be performed, including the codebase and platform descriptions.
+
+**options:**
+
+``-h, --help``
+    Display help message and exit.
+
+``--version``
+    Display version information and exit.
+
+``-x <pattern>, --exclude <pattern>``
+    Exclude files matching this pattern from the code base.
+    May be specified multiple times.
+
+``-p <platform>, --platform <platform>``
+    Include the specified platform in the analysis.
+    May be specified multiple times.
+    If not specified, all platforms will be included.
+
+``--prune``
+    Prune unused files from the tree.
+
+``-L <level>, --levels <level>``
+    Print only the specified number of levels.

--- a/docs/source/cmd.rst
+++ b/docs/source/cmd.rst
@@ -81,3 +81,34 @@ directory is annotated with information about platform usage and coverage.
 
 ``-L <level>, --levels <level>``
     Print only the specified number of levels.
+
+Coverage Tool
+-------------
+
+The coverage tool reads a JSON compilation database and generates a JSON
+coverage file that is suitable to be read by other tools.
+
+.. code-block:: text
+
+    cbi-cov compute [-h] [-S <path>] [-x <pattern>] [-o <output path>] <input path>
+
+**positional arguments:**
+
+``input path``
+    Path to compilation database JSON file.
+
+**options:**
+
+``-h, --help``
+    Display help message and exit.
+
+``-S <path>, --source-dir <path>``
+    Path to source directory.
+
+``-x <pattern>, --exclude <pattern>``
+    Exclude files matching this pattern from the code base.
+    May be specified multiple times.
+
+``-o <output path>, --output <output path>``
+    Path to coverage JSON file.
+    If not specified, defaults to 'coverage.json'.

--- a/docs/source/cmd.rst
+++ b/docs/source/cmd.rst
@@ -25,13 +25,15 @@ Command Line Interface
 ``-q, --quiet``
     Decrease verbosity level.
 
+``--debug``
+    Enable debug mode.
+
 ``-R <report>``
     Generate a report of the specified type.
 
     - ``summary``: code divergence information
     - ``clustering``: distance matrix and dendrogram
     - ``duplicates``: detected duplicate files
-    - ``files``: information about individual files
 
 ``-x <pattern>, --exclude <pattern>``
     Exclude files matching this pattern from the code base.

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -13,18 +13,18 @@ Although limited, this functionality is sufficient to support analysis of many
 HPC codes, and CBI has been tested on C, C++, CUDA and some Fortran code bases.
 
 
-Computing Code Divergence
-#########################
+Computing Specialization Metrics
+################################
 
-CBI computes code divergence by building a *specialization tree*, like the one
-shown below:
+CBI computes code divergence and platform coverage by building a
+*specialization tree*, like the one shown below:
 
 .. image:: specialization-tree.png
    :alt: An example of a specialization tree.
 
 CBI can then walk and evaluate this tree for different platform definitions, to
-produce a divergence report providing a breakdown of how many lines of code
-are shared between different platform sets.
+produce a report providing a breakdown of how many lines of code are shared
+between different platform sets.
 
 .. code:: text
 
@@ -46,9 +46,7 @@ are shared between different platform sets.
     Avg. Coverage (%): 42.44
     Total SLOC: 41
 
-Future releases of CBI will provide additional ways to visualize the results of
-this analysis, in order to highlight exactly *which* lines of code correspond
-to different platform sets.
+For more information about these metrics, see :doc:`here <specialization>`.
 
 
 Hierarchical Clustering
@@ -76,3 +74,28 @@ hierarchical clustering by platform similarity.
 
 .. image:: example-dendrogram.png
    :alt: A dendrogram representing the distance between platforms.
+
+
+Visualizing Platform Coverage
+#############################
+
+To assist developers in identifying exactly which parts of their code are
+specialized and for which platforms, CBI can produce an annotated tree showing
+the amount of specialization within each file.
+
+.. code:: text
+
+    Legend:
+    A: cpu
+    B: gpu
+
+    Columns:
+    [Platforms | SLOC | Coverage (%) | Avg. Coverage (%)]
+
+    [AB | 1.0k |   2.59 |   1.83] o /path/to/sample-code-base/src/
+    [-- | 1.0k |   0.00 |   0.00] |-- unused.cpp
+    [AB |   13 | 100.00 |  92.31] |-- main.cpp
+    [A- |    7 | 100.00 |  50.00] |-o cpu/
+    [A- |    7 | 100.00 |  50.00] | \-- foo.cpp
+    [-B |    7 | 100.00 |  50.00] \-o gpu/
+    [-B |    7 | 100.00 |  50.00]   \-- foo.cpp


### PR DESCRIPTION
# Related issues

N/A

# Proposed changes

- Remove documentation of features that are no longer available in 2.0.0.
- Add documentation for new command line interfaces (i.e., `cbi-cov` and `cbi-tree`).
- Work `cbi-tree` into the tutorial in relevant places, to highlight that it exists.
- Briefly mention custom compilers in the tutorial, with a link to more information for expert users.

---

As it says in the commit history, I'm reluctant to write a full-fledged tutorial for custom compiler behavior at this point.  The tutorial we have right now is really a quickstart guide, and I'm hoping that _most_ users won't have to define really complicated custom behaviors to get meaningful results. But I've added a note that people should file an issue if I'm wrong.

If it turns out that we need a better tutorial or more documentation for this feature, I think we can always do this after 2.0.0 releases.  There's no reason that we can't update the documentation independently.