### PR TITLE
Add definition of sycl-nvptx64-nvidia-cuda pass

### DIFF
--- a/codebasin/compilers/intel.toml
+++ b/codebasin/compilers/intel.toml
@@ -50,3 +50,8 @@ modes = ["sycl"]
 name = "sycl-spir64_fpga"
 defines = ["__SYCL_DEVICE_ONLY__", "__SPIR__", "__SPIRV__"]
 modes = ["sycl"]
+
+[[compiler.icx.passes]]
+name = "sycl-nvptx64-nvidia-cuda"
+defines = ["__SYCL_DEVICE_ONLY__", "__NVPTX__"]
+modes = ["sycl"]

--- a/tests/compilers/test_compilers.py
+++ b/tests/compilers/test_compilers.py
@@ -117,7 +117,7 @@ class TestCompilers(unittest.TestCase):
         argv = [
             "icpx",
             "-fsycl",
-            "-fsycl-targets=spir64,spir64_x86_64",
+            "-fsycl-targets=spir64,spir64_x86_64,nvptx64-nvidia-cuda",
             "-fopenmp",
             "test.cpp",
         ]
@@ -129,7 +129,12 @@ class TestCompilers(unittest.TestCase):
         pass_names = {p.pass_name for p in passes}
         self.assertCountEqual(
             pass_names,
-            {"default", "sycl-spir64", "sycl-spir64_x86_64"},
+            {
+                "default",
+                "sycl-spir64",
+                "sycl-spir64_x86_64",
+                "sycl-nvptx64-nvidia-cuda",
+            },
         )
 
         for p in passes:
@@ -144,6 +149,12 @@ class TestCompilers(unittest.TestCase):
                     "__SYCL_DEVICE_ONLY__",
                     "__SPIR__",
                     "__SPIRV__",
+                ]
+            elif p.pass_name == "sycl-nvptx64-nvidia-cuda":
+                expected = [
+                    "SYCL_LANGUAGE_VERSION",
+                    "__SYCL_DEVICE_ONLY__",
+                    "__NVPTX__",
                 ]
             self.assertCountEqual(p.defines, expected)
 


### PR DESCRIPTION
# Related issues

- I somehow missed this during #168.

# Proposed changes

- Add a regression test using `-fsycl-targets=nvptx64-nvidia-cuda`.
- Define the missing `sycl-nvptx64-nvidia-cuda` pass.
