### PR TITLE
Add progress tracker for identifying source files

### DIFF
--- a/codebasin/finder.py
+++ b/codebasin/finder.py
@@ -163,16 +163,32 @@ def find(
     if isinstance(rootdir, Path):
         rootdir = str(rootdir)
 
-    # Identify all of the files in the codebase.
+    # Build up a list of potential source files.
+    def _potential_file_generator(codebase):
+        for directory in codebase._directories:
+            yield from Path(directory).rglob("*")
+
+    potential_files = []
+    for f in tqdm(
+        _potential_file_generator(codebase),
+        desc="Scanning current directory",
+        unit=" files",
+        leave=False,
+        disable=not show_progress,
+    ):
+        potential_files.append(f)
+
+    # Identify which files are in the code base.
     filenames = set()
     for f in tqdm(
-        codebase,
+        potential_files,
         desc="Identifying source files",
         unit=" files",
         leave=False,
         disable=not show_progress,
     ):
-        filenames.add(f)
+        if f in codebase:
+            filenames.add(f)
     for p in configuration:
         for e in configuration[p]:
             filenames.add(e["file"])

--- a/codebasin/finder.py
+++ b/codebasin/finder.py
@@ -163,12 +163,22 @@ def find(
     if isinstance(rootdir, Path):
         rootdir = str(rootdir)
 
-    # Build a tree for each unique file for all platforms.
-    state = ParserState(summarize_only)
-    filenames = set(codebase)
+    # Identify all of the files in the codebase.
+    filenames = set()
+    for f in tqdm(
+        codebase,
+        desc="Identifying source files",
+        unit=" files",
+        leave=False,
+        disable=not show_progress,
+    ):
+        filenames.add(f)
     for p in configuration:
         for e in configuration[p]:
             filenames.add(e["file"])
+
+    # Build a tree for each unique file for all platforms.
+    state = ParserState(summarize_only)
     for f in tqdm(
         filenames,
         desc="Parsing",


### PR DESCRIPTION
If a code base contains many files (e.g., because a build directory was accidentally included) it can take a long time to identify the source files in the code base. This commit adds a progress tracker with tqdm to make it clear that CBI is doing something and hasn't just stalled.

We don't get a progress bar, because the number of files in the code base is not known a priori, but tqdm will print the number of files found so far.

# Related issues

- N/A

# Proposed changes

- Build up the `filenames` set programmatically instead of using `set(codebase)` so that we can track progress.
- Wrap most of the `filenames` construction in `tqdm`.

Note that the addition of files listed explicitly in the configuration (L176-L179) is _not_ tracked. In my testing, these three lines basically take no time at all.  The reason that `set(codebase)` takes so long is that the `CodeBase` iterator calls `rglob(*)` and checks _every_ path in the directory where `codebasin` is run -- so time scales with the number of files in the directory, not the number of files in the `compile_commands.json` file. It may be possible to improve the performance of this iterator, but I think we can treat that as orthogonal to this UX improvement.
