### PR TITLE
`util.py` module type hints

### DIFF
--- a/codebasin/util.py
+++ b/codebasin/util.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2019-2024 Intel Corporation
+# Copyright (C) 2019-2025 Intel Corporation
 # SPDX-License-Identifier: BSD-3-Clause
 """
 Contains utility functions for common operations, including:

--- a/codebasin/util.py
+++ b/codebasin/util.py
@@ -65,8 +65,40 @@ def safe_open_write_binary(fname: os.PathLike[str]) -> TextIOWrapper:
     return os.fdopen(fpid, "wb")
 
 
-def valid_path(path):
-    """Return true if the path passed in is valid"""
+def valid_path(path: os.PathLike[str]) -> bool:
+    """
+    Check if a given file path is valid.
+
+    This function ensures that the file path does not contain 
+    potentially dangerous characters such as null bytes (`\x00`)
+    or carriage returns/line feeds (`\n`, `\r`). These characters
+    can pose security risks, particularly in file handling operations.
+
+    Parameters
+    ----------
+    path : os.PathLike[str]
+        The file path to be validated.
+
+    Returns
+    -------
+    bool
+        A boolean value indicating whether the path is valid 
+        (`True`) or invalid (`False`).
+
+    Notes
+    -----
+    - This function is useful for validating file paths before performing 
+      file I/O operations to prevent security vulnerabilities.
+
+    Examples
+    --------
+    >>> valid_path("/home/user/file.txt")
+    True
+    >>> valid_path("/home/user/\x00file.txt")
+    False
+    >>> valid_path("/home/user/file\n.txt")
+    False
+    """
     valid = True
 
     # Check for null byte character(s)

--- a/codebasin/util.py
+++ b/codebasin/util.py
@@ -51,7 +51,7 @@ def ensure_ext(path: os.PathLike[str], extensions: Iterable[str]) -> None:
     extension = "".join(path.suffixes)
     if extension not in extensions:
         exts = ", ".join([f"'{ext}'" for ext in extensions])
-        raise ValueError(f"{path} does not have a valid extension: f{exts}")
+        raise ValueError(f"{path} does not have a valid extension: {exts}")
 
 
 def safe_open_write_binary(fname: os.PathLike[str]) -> typing.BinaryIO:

--- a/codebasin/util.py
+++ b/codebasin/util.py
@@ -229,7 +229,7 @@ def _load_json(file_object: typing.TextIO, schema_name: str) -> object:
     return json_object
 
 
-def _load_toml(file_object: typing.TextIO, schema_name: str) -> object:
+def _load_toml(file_object: typing.TextIO, schema_name: str) -> dict[str, typing.Any]:
     """
     Load TOML from file and validate it against a schema.
 
@@ -243,8 +243,9 @@ def _load_toml(file_object: typing.TextIO, schema_name: str) -> object:
 
     Returns
     -------
-    Object
-        The loaded TOML.
+    dict[str, Any]
+        The loaded TOML object, represented as a Python
+        dict with str key/value mappings.
 
     Raises
     ------

--- a/codebasin/util.py
+++ b/codebasin/util.py
@@ -7,6 +7,7 @@ Contains utility functions for common operations, including:
 - Checking paths
 """
 
+from io import TextIOWrapper
 import json
 import logging
 import os
@@ -54,7 +55,7 @@ def ensure_ext(path: os.PathLike[str], extensions: Iterable[str]) -> None:
         raise ValueError(f"{path} does not have a valid extension: f{exts}")
 
 
-def safe_open_write_binary(fname):
+def safe_open_write_binary(fname: os.PathLike[str]) -> TextIOWrapper:
     """Open fname for (binary) writing. Truncate if not a symlink."""
     fpid = os.open(
         fname,

--- a/codebasin/util.py
+++ b/codebasin/util.py
@@ -7,7 +7,6 @@ Contains utility functions for common operations, including:
 - Checking paths
 """
 
-from io import TextIOWrapper
 import json
 import logging
 import os
@@ -15,6 +14,7 @@ import pkgutil
 import tomllib
 import typing
 from collections.abc import Iterable
+from io import TextIOWrapper
 from pathlib import Path
 
 import jsonschema
@@ -69,7 +69,7 @@ def valid_path(path: os.PathLike[str]) -> bool:
     """
     Check if a given file path is valid.
 
-    This function ensures that the file path does not contain 
+    This function ensures that the file path does not contain
     potentially dangerous characters such as null bytes (`\x00`)
     or carriage returns/line feeds (`\n`, `\r`). These characters
     can pose security risks, particularly in file handling operations.
@@ -82,12 +82,12 @@ def valid_path(path: os.PathLike[str]) -> bool:
     Returns
     -------
     bool
-        A boolean value indicating whether the path is valid 
+        A boolean value indicating whether the path is valid
         (`True`) or invalid (`False`).
 
     Notes
     -----
-    - This function is useful for validating file paths before performing 
+    - This function is useful for validating file paths before performing
       file I/O operations to prevent security vulnerabilities.
 
     Examples
@@ -229,7 +229,10 @@ def _load_json(file_object: typing.TextIO, schema_name: str) -> object:
     return json_object
 
 
-def _load_toml(file_object: typing.TextIO, schema_name: str) -> dict[str, typing.Any]:
+def _load_toml(
+    file_object: typing.TextIO,
+    schema_name: str,
+) -> dict[str, typing.Any]:
     """
     Load TOML from file and validate it against a schema.
 

--- a/codebasin/util.py
+++ b/codebasin/util.py
@@ -70,8 +70,7 @@ def valid_path(path: os.PathLike[str]) -> bool:
 
     This function ensures that the file path does not contain
     potentially dangerous characters such as null bytes (`\x00`)
-    or carriage returns/line feeds (`\n`, `\r`). These characters
-    can pose security risks, particularly in file handling operations.
+    or carriage returns/line feeds (`\n`, `\r`).
 
     Parameters
     ----------
@@ -83,11 +82,6 @@ def valid_path(path: os.PathLike[str]) -> bool:
     bool
         A boolean value indicating whether the path is valid
         (`True`) or invalid (`False`).
-
-    Notes
-    -----
-    - This function is useful for validating file paths before performing
-      file I/O operations to prevent security vulnerabilities.
 
     Examples
     --------

--- a/codebasin/util.py
+++ b/codebasin/util.py
@@ -14,7 +14,6 @@ import pkgutil
 import tomllib
 import typing
 from collections.abc import Iterable
-from io import TextIOWrapper
 from pathlib import Path
 
 import jsonschema
@@ -55,7 +54,7 @@ def ensure_ext(path: os.PathLike[str], extensions: Iterable[str]) -> None:
         raise ValueError(f"{path} does not have a valid extension: f{exts}")
 
 
-def safe_open_write_binary(fname: os.PathLike[str]) -> TextIOWrapper:
+def safe_open_write_binary(fname: os.PathLike[str]) -> typing.BinaryIO:
     """Open fname for (binary) writing. Truncate if not a symlink."""
     fpid = os.open(
         fname,

--- a/codebasin/util.py
+++ b/codebasin/util.py
@@ -21,7 +21,7 @@ import jsonschema
 log = logging.getLogger(__name__)
 
 
-def ensure_ext(path: os.PathLike[str], extensions: Iterable[str]):
+def ensure_ext(path: os.PathLike[str], extensions: Iterable[str]) -> None:
     """
     Ensure that a path has one of the specified extensions.
 
@@ -32,11 +32,6 @@ def ensure_ext(path: os.PathLike[str], extensions: Iterable[str]):
 
     extensions: Iterable[str]
         The valid extensions to test against.
-
-    Returns
-    -------
-    bool
-        True if `path` is a file with one of the specified extensions.
 
     Raises
     ------


### PR DESCRIPTION
# Related issues

Closes #191, which is part of epic #182.

# Proposed changes

This PR makes (currently) purely aesthetic changes by adding type hints to function signatures contained in `util.py`, as well as updating docstrings to match implementations.

- Bumps copyright year at the beginning of the module
- Adds type annotations for `safe_open_write_binary`, `valid_path`
- Updated type annotations and docstrings for `ensure_ext`, `_load_toml`
