### PR TITLE
Prepare for 2.0.0 release

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,4 +1,4 @@
-cff-version: 1.2.0
+cff-version: 2.0.0
 message: "If you use this software, please cite it as below."
 authors:
 - family-names: "Sewall"
@@ -10,15 +10,18 @@ authors:
 - family-names: "Jacobsen"
   given-names: "Douglas"
   orcid: "https://orcid.org/0000-0002-3836-207X"
+- family-names: "Lee"
+  given-names: "Kin Long Kelvin"
+  orcid: "https://orcid.org/0000-0002-1903-9242"
 title: "Code Base Investigator"
-version: 1.2.0
-date-released: "2024-03-28"
-doi: "10.5281/zenodo.10890422"
+version: 2.0.0
+date-released: "2025-05-15"
+doi: "10.5281/zenodo.15422620"
 identifiers:
   - description: Archive of all previous releases.
     type: doi
     value: "10.5281/zenodo.5018973"
   - description: Latest release.
     type: doi
-    value: "10.5281/zenodo.10890422"
+    value: "10.5281/zenodo.15422620"
 url: "https://github.com/intel/code-base-investigator"

--- a/README.md
+++ b/README.md
@@ -49,9 +49,7 @@ The latest release of CBI is version 2.0.0. To download and install this
 release, run the following:
 
 ```
-git clone --branch 2.0.0 https://github.com/intel/code-base-investigator.git
-cd code-base-investigator
-pip install .
+pip install git+https://github.com/intel/code-base-investigator@2.0.0
 ```
 
 We strongly recommend installing CBI within a [virtual

--- a/README.md
+++ b/README.md
@@ -38,7 +38,6 @@ portability and maintainability of an application's source code.
 - NumPy
 - pathspec
 - Python 3
-- PyYAML
 - SciPy
 - tabulate
 - tqdm

--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ portability and maintainability of an application's source code.
 
 ## Installation
 
-The latest release of CBI is version 1.2.0. To download and install this
+The latest release of CBI is version 2.0.0. To download and install this
 release, run the following:
 
 ```
-git clone --branch 1.2.0 https://github.com/intel/code-base-investigator.git
+git clone --branch 2.0.0 https://github.com/intel/code-base-investigator.git
 cd code-base-investigator
 pip install .
 ```

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -13,8 +13,8 @@ copyright = (
     + "brands may be claimed as the property of others."
 )
 author = "Intel Corporation"
-version = "1.2.0"
-release = "1.2.0"
+version = "2.0.0"
+release = "2.0.0"
 
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -62,9 +62,7 @@ Installation
 The latest release of CBI is version 2.0.0. To download and install this
 release, run the following::
 
-    $ git clone --branch 2.0.0 https://github.com/intel/code-base-investigator.git
-    $ cd code-base-investigator
-    $ pip install .
+    $ pip install git+https://github.com/intel/code-base-investigator@2.0.0
 
 We strongly recommend installing CBI within a virtual environment, to simplify
 dependency management and improve security. Some alternative methods of

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -59,10 +59,10 @@ portability and maintainability of an application's source code.
 Installation
 ############
 
-The latest release of CBI is version 1.2.0. To download and install this
+The latest release of CBI is version 2.0.0. To download and install this
 release, run the following::
 
-    $ git clone --branch 1.2.0 https://github.com/intel/code-base-investigator.git
+    $ git clone --branch 2.0.0 https://github.com/intel/code-base-investigator.git
     $ cd code-base-investigator
     $ pip install .
 
@@ -74,7 +74,7 @@ creating a virtual environment are shown below.
 
     .. code-block:: text
 
-        $ git clone --branch 1.2.0 https://github.com/intel/code-base-investigator.git
+        $ git clone --branch 2.0.0 https://github.com/intel/code-base-investigator.git
         $ python3 -m venv cbi
         $ source cbi/bin/activate
         $ cd code-base-investigator
@@ -84,7 +84,7 @@ creating a virtual environment are shown below.
 
     .. code-block:: text
 
-        $ git clone --branch 1.2.0 https://github.com/intel/code-base-investigator.git
+        $ git clone --branch 2.0.0 https://github.com/intel/code-base-investigator.git
         $ cd code-base-investigator
         $ uv tool install .
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ description = "Code Base Investigator"
 dynamic = ["version", "readme"]
 keywords = ["performance", "portability", "productivity"]
 name = "codebasin"
-requires-python = ">=3.9"
+requires-python = ">=3.12"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Environment :: Console",
@@ -24,13 +24,13 @@ classifiers = [
   "Topic :: Software Development",
 ]
 dependencies = [
-  "numpy==1.26.0",
-  "matplotlib==3.8.2",
+  "numpy==2.2.4",
+  "matplotlib==3.10.1",
   "pathspec==0.12.1",
-  "scipy==1.12.0",
-  "jsonschema==4.21.1",
+  "scipy==1.15.2",
+  "jsonschema==4.23.0",
   "tabulate==0.9.0",
-  "tqdm==4.66.5",
+  "tqdm==4.67.1",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,6 @@ dependencies = [
   "numpy==1.26.0",
   "matplotlib==3.8.2",
   "pathspec==0.12.1",
-  "pyyaml==6.0.1",
   "scipy==1.12.0",
   "jsonschema==4.21.1",
   "tabulate==0.9.0",


### PR DESCRIPTION
# Related issues

N/A

# Proposed changes

- Remove unused dependencies.
- Update dependencies to latest versions.
- Update all version numbers from 1.2.0 to 2.0.0.
- Update CITATION.cff with a placeholder DOI from Zenodo and @laserkelvin as an author.

---

I set the date field to today, but I suspect the release will actually happen at some point in the next few days.  I'll need to update that immediately prior to the merge, but everything else can be reviewed now.
