### PR TITLE
Refactor Platform class as Preprocessor class

### DIFF
--- a/codebasin/finder.py
+++ b/codebasin/finder.py
@@ -238,7 +238,6 @@ def find(
         ):
             preprocessor = Preprocessor(
                 platform_name=p,
-                rootdir=rootdir,
                 include_paths=e["include_paths"],
                 defines=e["defines"],
             )

--- a/codebasin/finder.py
+++ b/codebasin/finder.py
@@ -128,6 +128,10 @@ class ParserState:
         association = self.get_map(filename)
         if tree is None or association is None:
             raise RuntimeError(f"Missing tree or association for '{filename}'")
+
+        if preprocessor.platform_name is None:
+            raise RuntimeError(f"Cannot associate '{filename}' with 'None'")
+
         branch_taken = []
 
         def associator(node: Node) -> Visit:

--- a/codebasin/finder.py
+++ b/codebasin/finder.py
@@ -14,9 +14,15 @@ from typing import Any
 
 from tqdm import tqdm
 
-from codebasin import CodeBase, file_parser, preprocessor
+from codebasin import CodeBase, file_parser
 from codebasin.language import FileLanguage
-from codebasin.preprocessor import CodeNode, Node, Platform, SourceTree, Visit
+from codebasin.preprocessor import (
+    CodeNode,
+    Node,
+    Preprocessor,
+    SourceTree,
+    Visit,
+)
 
 log = logging.getLogger(__name__)
 
@@ -114,9 +120,9 @@ class ParserState:
                 setmap[platform] += node.num_lines
         return setmap
 
-    def associate(self, filename: str, platform: Platform) -> None:
+    def associate(self, filename: str, preprocessor: Preprocessor) -> None:
         """
-        Update the association for the provided filename and platform.
+        Update the association for `filename` using `preprocessor`.
         """
         tree = self.get_tree(filename)
         association = self.get_map(filename)
@@ -125,9 +131,11 @@ class ParserState:
         branch_taken = []
 
         def associator(node: Node) -> Visit:
-            association[node].add(platform.name)
-            active = node.evaluate_for_platform(
-                platform=platform,
+            association[node].add(preprocessor.platform_name)
+
+            # TODO: Consider inverting, so preprocessor calls the function.
+            active = node.evaluate(
+                preprocessor=preprocessor,
                 filename=self._get_realpath(filename),
                 state=self,
             )
@@ -228,28 +236,27 @@ def find(
             leave=False,
             disable=not show_progress,
         ):
-            file_platform = Platform(p, rootdir)
-
-            for path in e["include_paths"]:
-                file_platform.add_include_path(path)
-
-            for definition in e["defines"]:
-                macro = preprocessor.macro_from_definition_string(definition)
-                file_platform.define(macro.name, macro)
+            preprocessor = Preprocessor(
+                platform_name=p,
+                rootdir=rootdir,
+                include_paths=e["include_paths"],
+                defines=e["defines"],
+            )
 
             # Process include files.
-            # These modify the file_platform instance, but we throw away
+            # These modify the preprocessor instance, but we throw away
             # the active nodes after processing is complete.
             for include in e["include_files"]:
-                include_file = file_platform.find_include_file(
+                include_file = preprocessor.find_include_file(
                     include,
                     os.path.dirname(e["file"]),
                 )
                 if include_file:
                     state.insert_file(include_file)
-                    state.associate(include_file, file_platform)
+                    state.associate(include_file, preprocessor)
 
             # Process the file, to build a list of associate nodes
-            state.associate(e["file"], file_platform)
+            # TODO: Consider inverting, so preprocessor calls the function.
+            state.associate(e["file"], preprocessor)
 
     return state

--- a/codebasin/preprocessor.py
+++ b/codebasin/preprocessor.py
@@ -1781,11 +1781,23 @@ class Preprocessor:
         is_system_include: bool = False,
     ) -> str | None:
         """
-        Determine and return the full path to an include file, named
-        'filename' using the include paths for this platform.
+        Determine and return the full path to `filename`.
 
-        System includes do not include the rootdir, while local includes
-        do.
+        Parameters
+        ----------
+        filename: str
+            The name of the include file to find.
+
+        this_path: str
+            The path where the preprocessor is currently running.
+
+        is_system_include: bool, default: False
+            Whether the include file is a system header or not.
+
+        Returns
+        -------
+        str | None
+            The full path to `filename` if it was found and `None` otherwise.
         """
         try:
             return self._found_incl[filename]

--- a/codebasin/preprocessor.py
+++ b/codebasin/preprocessor.py
@@ -1691,6 +1691,8 @@ class Preprocessor:
         self._include_paths: list[Path]
         if include_paths is None:
             self._include_paths = []
+        elif not isinstance(include_paths, list):
+            raise TypeError("'include_paths' must be a list of paths.")
         elif not all(
             [isinstance(p, (str, os.PathLike)) for p in include_paths],
         ):
@@ -1703,6 +1705,8 @@ class Preprocessor:
         self._definitions: dict[str, Macro | MacroFunction]
         if defines is None:
             self._definitions = {}
+        elif not isinstance(defines, list):
+            raise TypeError("'defines' must be a list of strings.")
         elif not all([isinstance(d, str) for d in defines]):
             raise TypeError("'defines' must be a list of strings.")
         else:

--- a/codebasin/preprocessor.py
+++ b/codebasin/preprocessor.py
@@ -1736,6 +1736,29 @@ class Preprocessor:
         if identifier.token in self._definitions:
             del self._definitions[identifier.token]
 
+    def get_macro(
+        self,
+        identifier: Identifier,
+    ) -> Macro | MacroFunction | None:
+        """
+        Returns
+        -------
+        Macro | MacroFunction | None
+            The macro associated with `identifier`, or None.
+        """
+        if identifier.token in self._definitions:
+            return self._definitions[identifier.token]
+        return None
+
+    def has_macro(self, identifier: Identifier) -> bool:
+        """
+        Returns
+        -------
+        bool
+            True if `identifier` is defined and False otherwise.
+        """
+        return self.get_macro(identifier) is not None
+
     def add_include_to_skip(self, fn: str) -> None:
         """
         Add an include file to the skip list for this platform. The file will
@@ -1750,30 +1773,6 @@ class Preprocessor:
         processed or skipped.
         """
         return fn not in self._skip_includes
-
-    # FIXME: This should return a bool, but the usage relies on a str.
-    def is_defined(self, identifier: str) -> str:
-        """
-        Return a string representing whether the macro named by 'identifier' is
-        defined.
-        """
-        if identifier in self._definitions:
-            return "1"
-        return "0"
-
-    def get_macro(
-        self,
-        identifier: Identifier,
-    ) -> Macro | MacroFunction | None:
-        """
-        Returns
-        -------
-        Macro | MacroFunction | None
-            The macro associated with `identifier`, or None.
-        """
-        if identifier.token in self._definitions:
-            return self._definitions[identifier.token]
-        return None
 
     def find_include_file(
         self,
@@ -1986,7 +1985,10 @@ class MacroExpander:
         """
         Expand a call to defined(X) or defined X.
         """
-        value = self.preprocessor.is_defined(str(identifier))
+        if self.preprocessor.has_macro(identifier):
+            value = "1"
+        else:
+            value = "0"
         return NumericalConstant(
             "EXPANSION",
             identifier.col,

--- a/codebasin/preprocessor.py
+++ b/codebasin/preprocessor.py
@@ -1663,7 +1663,6 @@ class Preprocessor:
     Represents a specific instance of a preprocessor, including:
     - Active macro definitions
     - Includes that should only be processed once
-    - The root directory
     - The name of the platform associated with this pre-processor
     """
 
@@ -1679,7 +1678,6 @@ class Preprocessor:
         self,
         *,
         platform_name: str | None = None,
-        rootdir: str | os.PathLike[str] | None = None,
         include_paths: list[str | os.PathLike[str]] | None = None,
         defines: list[str] | None = None,
     ) -> None:
@@ -1689,13 +1687,6 @@ class Preprocessor:
             raise TypeError("'platform_name' must be a string.")
         else:
             self.platform_name = platform_name
-
-        if rootdir is None:
-            self.rootdir = None
-        elif not isinstance(rootdir, (str, os.PathLike)):
-            raise TypeError("'rootdir' must be PathLike.")
-        else:
-            self.rootdir = Path(rootdir)
 
         self._include_paths: list[Path]
         if include_paths is None:

--- a/codebasin/preprocessor.py
+++ b/codebasin/preprocessor.py
@@ -1799,28 +1799,20 @@ class Preprocessor:
         str | None
             The full path to `filename` if it was found and `None` otherwise.
         """
-        try:
+        if filename in self._found_incl:
             return self._found_incl[filename]
-        except KeyError:
-            pass
-
-        include_file = None
 
         local_paths = []
         if not is_system_include:
             local_paths += [this_path]
 
-        # Determine the path to the include file, if it exists
         for path in local_paths + self._include_paths:
             test_path = os.path.abspath(os.path.join(path, filename))
             if os.path.isfile(test_path):
-                include_file = test_path
-                self._found_incl[filename] = include_file
-                return include_file
+                self._found_incl[filename] = test_path
+                return test_path
 
         # TODO: Check this optimization is always valid.
-        if include_file is not None:
-            raise RuntimeError(f"Expected 'None', got '{filename}'")
         self._found_incl[filename] = None
         return None
 

--- a/tests/macro_expansion/test_macro_expansion.py
+++ b/tests/macro_expansion/test_macro_expansion.py
@@ -6,7 +6,7 @@ import unittest
 from pathlib import Path
 
 from codebasin import CodeBase, finder, preprocessor
-from codebasin.preprocessor import Platform
+from codebasin.preprocessor import Preprocessor
 
 
 class TestMacroExpansion(unittest.TestCase):
@@ -63,7 +63,7 @@ class TestMacroExpansion(unittest.TestCase):
         test_str = "CATTEST=first ## 2"
         macro = preprocessor.macro_from_definition_string(test_str)
         tokens = preprocessor.Lexer("CATTEST").tokenize()
-        p = Platform("Test", self.rootdir)
+        p = Preprocessor(platform_name="Test", rootdir=self.rootdir)
         p._definitions = {macro.name: macro}
         expanded_tokens = preprocessor.MacroExpander(p).expand(tokens)
         expected_tokens = preprocessor.Lexer("first2").tokenize()
@@ -76,7 +76,7 @@ class TestMacroExpansion(unittest.TestCase):
         test_str = "STR(x)= #x"
         macro = preprocessor.macro_from_definition_string(test_str)
         tokens = preprocessor.Lexer('STR(foo("4 + 5"))').tokenize()
-        p = Platform("Test", self.rootdir)
+        p = Preprocessor(platform_name="Test", rootdir=self.rootdir)
         p._definitions = {macro.name: macro}
         expanded_tokens = preprocessor.MacroExpander(p).expand(tokens)
         expected_tokens = preprocessor.Lexer('"foo(\\"4 + 5\\")"').tokenize()
@@ -90,7 +90,7 @@ class TestMacroExpansion(unittest.TestCase):
         macro = preprocessor.macro_from_definition_string(test_str)
         to_expand_str = r'STR(L      + 2-2 "\" \n")'
         tokens = preprocessor.Lexer(to_expand_str).tokenize()
-        p = Platform("Test", self.rootdir)
+        p = Preprocessor(platform_name="Test", rootdir=self.rootdir)
         p._definitions = {macro.name: macro}
         expanded_tokens = preprocessor.MacroExpander(p).expand(tokens)
         expected_str = r'TEST "L + 2-2 \"\\\" \\n\""'
@@ -104,7 +104,7 @@ class TestMacroExpansion(unittest.TestCase):
         mac_xstr = preprocessor.macro_from_definition_string("xstr(s)=str(s)")
         mac_str = preprocessor.macro_from_definition_string("str(s)=#s")
         mac_def = preprocessor.macro_from_definition_string("foo=4")
-        p = Platform("Test", self.rootdir)
+        p = Preprocessor(platform_name="Test", rootdir=self.rootdir)
         p._definitions = {x.name: x for x in [mac_xstr, mac_str, mac_def]}
 
         tokens = preprocessor.Lexer("str(foo)").tokenize()
@@ -149,7 +149,7 @@ class TestMacroExpansion(unittest.TestCase):
             tokens = preprocessor.Lexer(
                 'eprintf("%d, %f, %e", a, b, c)',
             ).tokenize()
-            p = Platform("Test", self.rootdir)
+            p = Preprocessor(platform_name="Test", rootdir=self.rootdir)
             p._definitions = {macro.name: macro}
             expanded_tokens = preprocessor.MacroExpander(p).expand(tokens)
             self.assertTrue(len(expanded_tokens) == len(expected_expansion))
@@ -173,7 +173,7 @@ class TestMacroExpansion(unittest.TestCase):
         def_string = "FOO=(4 + FOO)"
         macro = preprocessor.macro_from_definition_string(def_string)
         tokens = preprocessor.Lexer("FOO").tokenize()
-        p = Platform("Test", self.rootdir)
+        p = Preprocessor(platform_name="Test", rootdir=self.rootdir)
         p._definitions = {macro.name: macro}
         expanded_tokens = preprocessor.MacroExpander(p).expand(tokens)
         self.assertTrue(len(expanded_tokens) == len(expected_expansion))
@@ -202,7 +202,7 @@ class TestMacroExpansion(unittest.TestCase):
         def_string = "FOO=FOO"
         macro = preprocessor.macro_from_definition_string(def_string)
         tokens = preprocessor.Lexer("FOO").tokenize()
-        p = Platform("Test", self.rootdir)
+        p = Preprocessor(platform_name="Test", rootdir=self.rootdir)
         p._definitions = {macro.name: macro}
         expanded_tokens = preprocessor.MacroExpander(p).expand(tokens)
         self.assertTrue(len(expanded_tokens) == len(expected_expansion))
@@ -227,7 +227,7 @@ class TestMacroExpansion(unittest.TestCase):
         def_string = "foo(x)=bar x"
         macro = preprocessor.macro_from_definition_string(def_string)
         tokens = preprocessor.Lexer("foo(foo) (2)").tokenize()
-        p = Platform("Test", self.rootdir)
+        p = Preprocessor(platform_name="Test", rootdir=self.rootdir)
         p._definitions = {macro.name: macro}
         expanded_tokens = preprocessor.MacroExpander(p).expand(tokens)
         expected_tokens = preprocessor.Lexer("bar foo (2)").tokenize()
@@ -271,7 +271,7 @@ class TestMacroExpansion(unittest.TestCase):
         x_tokens = preprocessor.Lexer("x").tokenize()
         y_tokens = preprocessor.Lexer("y").tokenize()
 
-        p = Platform("Test", self.rootdir)
+        p = Preprocessor(platform_name="Test", rootdir=self.rootdir)
         p._definitions = {x_macro.name: x_macro, y_macro.name: y_macro}
 
         x_expanded_tokens = preprocessor.MacroExpander(p).expand(x_tokens)

--- a/tests/macro_expansion/test_macro_expansion.py
+++ b/tests/macro_expansion/test_macro_expansion.py
@@ -63,7 +63,7 @@ class TestMacroExpansion(unittest.TestCase):
         test_str = "CATTEST=first ## 2"
         macro = preprocessor.macro_from_definition_string(test_str)
         tokens = preprocessor.Lexer("CATTEST").tokenize()
-        p = Preprocessor(platform_name="Test", rootdir=self.rootdir)
+        p = Preprocessor(platform_name="Test")
         p._definitions = {macro.name: macro}
         expanded_tokens = preprocessor.MacroExpander(p).expand(tokens)
         expected_tokens = preprocessor.Lexer("first2").tokenize()
@@ -76,7 +76,7 @@ class TestMacroExpansion(unittest.TestCase):
         test_str = "STR(x)= #x"
         macro = preprocessor.macro_from_definition_string(test_str)
         tokens = preprocessor.Lexer('STR(foo("4 + 5"))').tokenize()
-        p = Preprocessor(platform_name="Test", rootdir=self.rootdir)
+        p = Preprocessor(platform_name="Test")
         p._definitions = {macro.name: macro}
         expanded_tokens = preprocessor.MacroExpander(p).expand(tokens)
         expected_tokens = preprocessor.Lexer('"foo(\\"4 + 5\\")"').tokenize()
@@ -90,7 +90,7 @@ class TestMacroExpansion(unittest.TestCase):
         macro = preprocessor.macro_from_definition_string(test_str)
         to_expand_str = r'STR(L      + 2-2 "\" \n")'
         tokens = preprocessor.Lexer(to_expand_str).tokenize()
-        p = Preprocessor(platform_name="Test", rootdir=self.rootdir)
+        p = Preprocessor(platform_name="Test")
         p._definitions = {macro.name: macro}
         expanded_tokens = preprocessor.MacroExpander(p).expand(tokens)
         expected_str = r'TEST "L + 2-2 \"\\\" \\n\""'
@@ -104,7 +104,7 @@ class TestMacroExpansion(unittest.TestCase):
         mac_xstr = preprocessor.macro_from_definition_string("xstr(s)=str(s)")
         mac_str = preprocessor.macro_from_definition_string("str(s)=#s")
         mac_def = preprocessor.macro_from_definition_string("foo=4")
-        p = Preprocessor(platform_name="Test", rootdir=self.rootdir)
+        p = Preprocessor(platform_name="Test")
         p._definitions = {x.name: x for x in [mac_xstr, mac_str, mac_def]}
 
         tokens = preprocessor.Lexer("str(foo)").tokenize()
@@ -149,7 +149,7 @@ class TestMacroExpansion(unittest.TestCase):
             tokens = preprocessor.Lexer(
                 'eprintf("%d, %f, %e", a, b, c)',
             ).tokenize()
-            p = Preprocessor(platform_name="Test", rootdir=self.rootdir)
+            p = Preprocessor(platform_name="Test")
             p._definitions = {macro.name: macro}
             expanded_tokens = preprocessor.MacroExpander(p).expand(tokens)
             self.assertTrue(len(expanded_tokens) == len(expected_expansion))
@@ -173,7 +173,7 @@ class TestMacroExpansion(unittest.TestCase):
         def_string = "FOO=(4 + FOO)"
         macro = preprocessor.macro_from_definition_string(def_string)
         tokens = preprocessor.Lexer("FOO").tokenize()
-        p = Preprocessor(platform_name="Test", rootdir=self.rootdir)
+        p = Preprocessor(platform_name="Test")
         p._definitions = {macro.name: macro}
         expanded_tokens = preprocessor.MacroExpander(p).expand(tokens)
         self.assertTrue(len(expanded_tokens) == len(expected_expansion))
@@ -202,7 +202,7 @@ class TestMacroExpansion(unittest.TestCase):
         def_string = "FOO=FOO"
         macro = preprocessor.macro_from_definition_string(def_string)
         tokens = preprocessor.Lexer("FOO").tokenize()
-        p = Preprocessor(platform_name="Test", rootdir=self.rootdir)
+        p = Preprocessor(platform_name="Test")
         p._definitions = {macro.name: macro}
         expanded_tokens = preprocessor.MacroExpander(p).expand(tokens)
         self.assertTrue(len(expanded_tokens) == len(expected_expansion))
@@ -227,7 +227,7 @@ class TestMacroExpansion(unittest.TestCase):
         def_string = "foo(x)=bar x"
         macro = preprocessor.macro_from_definition_string(def_string)
         tokens = preprocessor.Lexer("foo(foo) (2)").tokenize()
-        p = Preprocessor(platform_name="Test", rootdir=self.rootdir)
+        p = Preprocessor(platform_name="Test")
         p._definitions = {macro.name: macro}
         expanded_tokens = preprocessor.MacroExpander(p).expand(tokens)
         expected_tokens = preprocessor.Lexer("bar foo (2)").tokenize()
@@ -271,7 +271,7 @@ class TestMacroExpansion(unittest.TestCase):
         x_tokens = preprocessor.Lexer("x").tokenize()
         y_tokens = preprocessor.Lexer("y").tokenize()
 
-        p = Preprocessor(platform_name="Test", rootdir=self.rootdir)
+        p = Preprocessor(platform_name="Test")
         p._definitions = {x_macro.name: x_macro, y_macro.name: y_macro}
 
         x_expanded_tokens = preprocessor.MacroExpander(p).expand(x_tokens)

--- a/tests/operators/test_operators.py
+++ b/tests/operators/test_operators.py
@@ -53,7 +53,7 @@ class TestOperators(unittest.TestCase):
     def test_paths(self):
         input_str = r"FUNCTION(looks/2like/a/path/with_/bad%%identifiers)"
         tokens = preprocessor.Lexer(input_str).tokenize()
-        p = Preprocessor(platform_name="Test", rootdir=self.rootdir)
+        p = Preprocessor(platform_name="Test")
         macro = preprocessor.macro_from_definition_string("FUNCTION(x)=#x")
         p._definitions = {macro.name: macro}
         _ = preprocessor.MacroExpander(p).expand(tokens)

--- a/tests/operators/test_operators.py
+++ b/tests/operators/test_operators.py
@@ -6,7 +6,7 @@ import unittest
 from pathlib import Path
 
 from codebasin import CodeBase, finder, preprocessor
-from codebasin.preprocessor import Platform
+from codebasin.preprocessor import Preprocessor
 
 
 class TestOperators(unittest.TestCase):
@@ -53,7 +53,7 @@ class TestOperators(unittest.TestCase):
     def test_paths(self):
         input_str = r"FUNCTION(looks/2like/a/path/with_/bad%%identifiers)"
         tokens = preprocessor.Lexer(input_str).tokenize()
-        p = Platform("Test", self.rootdir)
+        p = Preprocessor(platform_name="Test", rootdir=self.rootdir)
         macro = preprocessor.macro_from_definition_string("FUNCTION(x)=#x")
         p._definitions = {macro.name: macro}
         _ = preprocessor.MacroExpander(p).expand(tokens)

--- a/tests/preprocessor/test_preprocessor.py
+++ b/tests/preprocessor/test_preprocessor.py
@@ -44,7 +44,19 @@ class TestPreprocessor(unittest.TestCase):
             Preprocessor(include_paths="/not/a/list")
 
         with self.assertRaises(TypeError):
-            Preprocessor(defines="/not/a/list")
+            Preprocessor(include_paths=1)
+
+        with self.assertRaises(TypeError):
+            Preprocessor(include_paths=["/path/to/include", 1])
+
+        with self.assertRaises(TypeError):
+            Preprocessor(defines="NOT_A_LIST")
+
+        with self.assertRaises(TypeError):
+            Preprocessor(defines=1)
+
+        with self.assertRaises(TypeError):
+            Preprocessor(defines=["MACRO", 1])
 
     def test_define(self):
         """Check implementation of define"""

--- a/tests/preprocessor/test_preprocessor.py
+++ b/tests/preprocessor/test_preprocessor.py
@@ -1,0 +1,87 @@
+# Copyright (C) 2019-2024 Intel Corporation
+# SPDX-License-Identifier: BSD-3-Clause
+
+import logging
+import unittest
+from pathlib import Path
+
+import codebasin
+from codebasin.preprocessor import Identifier, Preprocessor
+
+
+class TestPreprocessor(unittest.TestCase):
+    """
+    Test Preprocessor class.
+    """
+
+    @classmethod
+    def setUpClass(self):
+        logging.disable()
+
+    def test_constructor(self):
+        """Check arguments are handled correctly"""
+        preprocessor = Preprocessor(
+            platform_name="name",
+            include_paths=["/path/to/include"],
+            defines=["MACRO"],
+        )
+        self.assertEqual(preprocessor.platform_name, "name")
+        self.assertCountEqual(
+            preprocessor._include_paths,
+            [Path("/path/to/include")],
+        )
+
+        macro = codebasin.preprocessor.macro_from_definition_string("MACRO")
+        self.assertCountEqual(preprocessor._definitions, {"MACRO": macro})
+
+    def test_constructor_validation(self):
+        """Check arguments are valid"""
+
+        with self.assertRaises(TypeError):
+            Preprocessor(platform_name=1)
+
+        with self.assertRaises(TypeError):
+            Preprocessor(include_paths="/not/a/list")
+
+        with self.assertRaises(TypeError):
+            Preprocessor(defines="/not/a/list")
+
+    def test_define(self):
+        """Check implementation of define"""
+        macro = codebasin.preprocessor.macro_from_definition_string("MACRO=x")
+        identifier = Identifier("Unknown", -1, False, "MACRO")
+
+        preprocessor = Preprocessor()
+        self.assertFalse(preprocessor.has_macro(identifier))
+        self.assertIsNone(preprocessor.get_macro(identifier))
+
+        preprocessor.define(macro)
+        self.assertTrue(preprocessor.has_macro(identifier))
+        self.assertEqual(preprocessor.get_macro(identifier), macro)
+
+    def test_undefine(self):
+        """Check implementation of undefine"""
+        macro = codebasin.preprocessor.macro_from_definition_string("MACRO=x")
+        identifier = Identifier("Unknown", -1, False, "MACRO")
+
+        preprocessor = Preprocessor()
+        preprocessor.define(macro)
+        preprocessor.undefine(identifier)
+
+        self.assertFalse(preprocessor.has_macro(identifier))
+        self.assertIsNone(preprocessor.get_macro(identifier))
+
+    def test_get_file_info(self):
+        """Check implementation of get_file_info"""
+        preprocessor = Preprocessor()
+
+        info = preprocessor.get_file_info("filename")
+        self.assertFalse(info.is_include_once)
+
+        preprocessor.get_file_info("filename").is_include_once = True
+        info = preprocessor.get_file_info("filename")
+        self.assertTrue(info.is_include_once)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
# Related issues

- Follow up to #198.

# Proposed changes

- Rename `Platform` to `Preprocessor`, since `Platform` is not consistent with how we use the name "platform" elsewhere.
- Simplify `Preprocessor` API to improve readability.
